### PR TITLE
Filebeat scalability fixes and new values variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+*.orig

--- a/README.md
+++ b/README.md
@@ -1,4 +1,45 @@
-# Installation procedures
+# Malcolm Helm Chart
+
+The purpose of this project is to make installing Malcolm with all of its server and sensor components easily across a 
+large Kubernetes cluster. Case in point, lets say you have 8 servers and 50 sensors. Some sensors will be high bandwidth 
+while others may be low bandwith. This helm chart for example can either deploy a opensearch setup or point to a 
+preconfigured external elasticsearch.  Furthermore, it will deploy live sensors for suricata and zeek as well as offline 
+deployment for uploading pcaps offline.
+
+## Features
+
+- Opensearch or External Elastic
+- Netbox
+- PCAP capture
+- Arkime PCAP Capture (Not implemented yet)
+- Suricata Live
+- Zeek Live
+- Offline PCAP Processing
+- Zeek file extraction 
+
+## Cluster Requirements
+
+The following requirements are assumed to be met prior to running the Installation procedures.  
+Other Kuberenetes clusters may work but they have not been tested
+
+- Kubernetes RKE2 installation v1.24.10+rke2r1
+- Storage class https://github.com/rancher/local-path-provisioner
+- Istio service mesh https://istio.io/latest/docs/setup/getting-started/
+- TOOD add better instructions for setting up istio service mesh
+- TODO add support for basic ingress and TLS
+- TODO support longhorn storage class for multi node setup
+
+When installing the localprovisioner update teh config.json run `kubectl edit configmap local-path-config -n local-path-storage`.
+Change the config.json file to look like the following.
+
+config.json: |-
+  {
+    "sharedFileSystemPath": "/opt/local-path-provisioner"
+  }
+
+## Installation procedures
+
+Check the chart/values.yaml file for all the features that can be enabled disabled and tweaked prior to running the below installation commands.
 
 1. `git clone <repo url>`
 2. `cd <project dir that contains chart foler>`
@@ -17,5 +58,6 @@ Malcolm services can be accessed via the following URLs:
   - PCAP upload (web): https://yourhostname/upload/
   - PCAP upload (sftp): sftp://username@yourhostname:8022/files/
   - NetBox: https://yourhostname/netbox/
+  - Extracted files: https://yourhostname/dl-extracted-files/  
   - Account management: https://yourhostname/auth/
   - Documentation: https://yourhostname/readme/

--- a/chart/templates/02-volumes.yml
+++ b/chart/templates/02-volumes.yml
@@ -1,44 +1,43 @@
-{{- with .Values.storage }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: pcap-claim
 spec:
-  storageClassName: {{ .pcap_claim.className }}
+  storageClassName: {{ .Values.storage.pcap_claim.className }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
   resources:
     requests:
-      storage: {{ .pcap_claim.size }}
+      storage: {{ .Values.storage.pcap_claim.size }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: zeek-claim
 spec:
-  storageClassName: {{ .zeek_claim.className }}
+  storageClassName: {{ .Values.storage.zeek_claim.className }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
   resources:
     requests:
-      storage: {{ .zeek_claim.size }}
+      storage: {{ .Values.storage.zeek_claim.size }}
 
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: suricata-claim
+  name: suricata-claim-offline
 spec:
-  storageClassName: {{ .suricata_claim.className }}
+  storageClassName: {{ .Values.storage.suricata_claim.className }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
   resources:
     requests:
-      storage: {{ .suricata_claim.size }}
+      storage: {{ .Values.storage.suricata_claim.size }}
 
 ---
 apiVersion: v1
@@ -46,13 +45,13 @@ kind: PersistentVolumeClaim
 metadata:
   name: config-claim
 spec:
-  storageClassName: {{ .config_claim.className }}
+  storageClassName: {{ .Values.storage.config_claim.className }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
   resources:
     requests:
-      storage: {{ .config_claim.size }}
+      storage: {{ .Values.storage.config_claim.size }}
 
 ---
 apiVersion: v1
@@ -60,27 +59,28 @@ kind: PersistentVolumeClaim
 metadata:
   name: runtime-logs-claim
 spec:
-  storageClassName: {{ .runtime_logs_claim.className }}
+  storageClassName: {{ .Values.storage.runtime_logs_claim.className }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
   resources:
     requests:
-      storage: {{ .runtime_logs_claim.size }}
+      storage: {{ .Values.storage.runtime_logs_claim.size }}
 
+{{- if .Values.opensearch.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: opensearch-claim
 spec:
-  storageClassName: {{ .opensearch_claim.className }}
+  storageClassName: {{ .Values.storage.opensearch_claim.className }}
   accessModes:
     - ReadWriteOnce
   volumeMode: Filesystem
   resources:
     requests:
-      storage: {{ .opensearch_claim.size }}
+      storage: {{ .Values.storage.opensearch_claim.size }}
 
 ---
 apiVersion: v1
@@ -88,11 +88,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: opensearch-backup-claim
 spec:
-  storageClassName: {{ .opensearch_backup_claim.className }}
+  storageClassName: {{ .Values.storage.opensearch_backup_claim.className }}
   accessModes:
     - ReadWriteOnce
   volumeMode: Filesystem
   resources:
     requests:
-      storage: {{ .opensearch_backup_claim.size }}
+      storage: {{ .Values.storage.opensearch_backup_claim.size }}
 {{- end }}

--- a/chart/templates/11-suricata.yml
+++ b/chart/templates/11-suricata.yml
@@ -104,7 +104,7 @@ spec:
             claimName: pcap-claim
         - name: suricata-offline-suricata-logs-volume
           persistentVolumeClaim:
-            claimName: suricata-claim
+            claimName: suricata-claim-offline
         - name: suricata-offline-custom-rules-volume
           configMap:
             name: suricata-rules

--- a/chart/templates/11-suricata.yml
+++ b/chart/templates/11-suricata.yml
@@ -19,8 +19,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: suricata-offline-deployment
-  
+  name: suricata-offline-deployment  
 spec:
   selector:
     matchLabels:

--- a/chart/templates/13-filebeat.yml
+++ b/chart/templates/13-filebeat.yml
@@ -1,15 +1,15 @@
 ---
 apiVersion: v1
 data:
-  FILEBEAT_CLEAN_INACTIVE: 180m
+  FILEBEAT_CLEAN_INACTIVE: {{ .Values.filebeat.filebeat_clean_inactive }}
   FILEBEAT_CLEAN_REMOVED: "true"
   FILEBEAT_CLOSE_EOF: "true"
-  FILEBEAT_CLOSE_INACTIVE: 120s
-  FILEBEAT_CLOSE_INACTIVE_LIVE: 90m
+  FILEBEAT_CLOSE_INACTIVE: {{ .Values.filebeat.filebeat_close_inactive }}
+  FILEBEAT_CLOSE_INACTIVE_LIVE: {{ .Values.filebeat.filebeat_close_inactive_live }}
   FILEBEAT_CLOSE_REMOVED: "true"
   FILEBEAT_CLOSE_RENAMED: "true"
-  FILEBEAT_IGNORE_OLDER: 120m
-  FILEBEAT_SCAN_FREQUENCY: 10s
+  FILEBEAT_IGNORE_OLDER: {{ .Values.filebeat.filebeat_ignore_older }}
+  FILEBEAT_SCAN_FREQUENCY: {{ .Values.filebeat.filebeat_scan_frequency }}
   FILEBEAT_TCP_LISTEN: "true"
   FILEBEAT_TCP_LOG_FORMAT: json
   FILEBEAT_TCP_PARSE_DROP_FIELD: message
@@ -27,7 +27,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: filebeat
-  
 spec:
   # use "type: ClusterIP" if using Ingress-NGINX as illustrated in 99-ingress-nginx.yml.example
   # use "type: LoadBalancer" if using AWS Load Balancer as illustrated in 99-ingress-alb.yml.example
@@ -37,23 +36,138 @@ spec:
       protocol: TCP
       name: tcpjson
   selector:
-    name: filebeat-deployment
+    name: filebeat-daemonset
 
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: filebeat-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: filebeat-daemonset
+  template:
+    metadata:
+      labels:
+        name: filebeat-daemonset
+    spec:
+      affinity:    
+{{ toYaml .Values.filebeat.nodeAffinity | indent 8 }}
+      tolerations:
+{{ toYaml .Values.live_capture.tolerations | indent 6 }}
+      containers:
+      - name: filebeat-container
+        image: "{{ .Values.image.repository }}/filebeat-oss:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        stdin: false
+        tty: true
+        ports:
+          - name: tcpjson
+            protocol: TCP
+            containerPort: 5045
+        envFrom:
+          - configMapRef:
+              name: process-env
+          - configMapRef:
+              name: ssl-env
+          - configMapRef:
+              name: nginx-env
+          - configMapRef:
+              name: opensearch-env
+          - configMapRef:
+              name: upload-common-env
+          - configMapRef:
+              name: beats-common-env
+          - configMapRef:
+              name: filebeat-env
+        env:
+          - name: PCAP_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: FILEBEAT_ZEEK_LOG_LIVE_PATH
+            value: "/zeek-live-logs/live"
+        livenessProbe:
+          exec:
+            command:
+            - supervisorctl
+            - status
+            - filebeat
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 15
+          successThreshold: 1
+          failureThreshold: 10
+        volumeMounts:
+          - mountPath: /var/local/ca-trust/configmap
+            name: filebeat-var-local-catrust-volume
+          - mountPath: /var/local/curlrc/secretmap
+            name: filebeat-opensearch-curlrc-secret-volume
+          - mountPath: /certs/secretmap
+            name: filebeat-certs-secret-volume
+          - mountPath: "/zeek"
+            name: filebeat-zeek-volume
+          - mountPath: "/suricata"
+            name: filebeat-suricata-live-volume
+          - name: filebeat-nginx-runtime-logs-volume
+            mountPath: /nginx
+            subPath: "nginx"
+          - mountPath: "/zeek-live-logs"
+            name: zeek-live-logs-volume
+      initContainers:
+      - name: filebeat-dirinit-container
+        image: "{{ .Values.image.repository }}/dirinit:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        stdin: false
+        tty: true
+        envFrom:
+          - configMapRef:
+              name: process-env
+        env:
+          - name: PUSER_MKDIR
+            value: "/data/runtime-logs:nginx"
+        volumeMounts:
+          - name: filebeat-nginx-runtime-logs-volume
+            mountPath: "/data/runtime-logs"
+      volumes:
+        - name: filebeat-var-local-catrust-volume
+          configMap:
+            name: var-local-catrust
+        - name: filebeat-opensearch-curlrc-secret-volume
+          secret:
+            secretName: opensearch-curlrc
+        - name: filebeat-certs-secret-volume
+          secret:
+            secretName: filebeat-certs
+        - name: filebeat-zeek-volume
+          persistentVolumeClaim:
+            claimName: zeek-claim
+        - name: filebeat-suricata-live-volume
+          hostPath:
+            path: "{{ .Values.suricata_live.suricata_log_path }}"
+            type: DirectoryOrCreate
+        - name: zeek-live-logs-volume
+          hostPath:
+            path: "{{ .Values.zeek_live.zeek_log_path }}"
+            type: DirectoryOrCreate
+        - name: filebeat-nginx-runtime-logs-volume
+          persistentVolumeClaim:
+            claimName: runtime-logs-claim
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: filebeat-deployment
-  
+  name: filebeat-offline-deployment
 spec:
   selector:
     matchLabels:
-      name: filebeat-deployment
+      name: filebeat-offline-deployment
   replicas: 1
   template:
     metadata:
       labels:
-        name: filebeat-deployment
+        name: filebeat-offline-deployment
     spec:
       containers:
       - name: filebeat-container
@@ -85,6 +199,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: FILEBEAT_SURICATA_LOG_PATH
+            value: /suricata-offline
         livenessProbe:
           exec:
             command:
@@ -105,8 +221,8 @@ spec:
             name: filebeat-certs-secret-volume
           - mountPath: "/zeek"
             name: filebeat-zeek-volume
-          - mountPath: "/suricata"
-            name: filebeat-suricata-volume
+          - mountPath: "/suricata-offline"
+            name: filebeat-suricata-offline-volume
           - name: filebeat-nginx-runtime-logs-volume
             mountPath: /nginx
             subPath: "nginx"
@@ -138,9 +254,9 @@ spec:
         - name: filebeat-zeek-volume
           persistentVolumeClaim:
             claimName: zeek-claim
-        - name: filebeat-suricata-volume
+        - name: filebeat-suricata-offline-volume
           persistentVolumeClaim:
-            claimName: suricata-claim
+            claimName: suricata-claim-offline
         - name: filebeat-nginx-runtime-logs-volume
           persistentVolumeClaim:
             claimName: runtime-logs-claim

--- a/chart/templates/21-zeek-live.yml
+++ b/chart/templates/21-zeek-live.yml
@@ -63,6 +63,8 @@ spec:
           - configMapRef:
               name: pcap-capture-env
         env:
+          - name: ZEEK_LOG_PATH
+            value: "/zeek-live-logs/live"
           - name: ZEEK_DISABLED
             value: "false"
           - name: PCAP_NODE_NAME
@@ -81,6 +83,8 @@ spec:
           - mountPath: "/zeek/live"
             name: zeek-live-zeek-volume
             subPath: "live"
+          - mountPath: "/zeek-live-logs"
+            name: zeek-live-logs-volume
           - mountPath: "/opt/zeek/share/zeek/site/intel"
             name: zeek-live-zeek-intel
             subPath: "zeek/intel"
@@ -95,12 +99,14 @@ spec:
               name: process-env
         env:
           - name: PUSER_MKDIR
-            value: "/data/config:zeek/intel/MISP,zeek/intel/STIX;/data/zeek-logs:current,extract_files/preserved,extract_files/quarantine,live,processed,upload"
+            value: "/data/config:zeek/intel/MISP,zeek/intel/STIX;/data/zeek-shared:current,extract_files/preserved,extract_files/quarantine,processed,upload;/zeek-live-logs:live"
         volumeMounts:
           - name: zeek-live-zeek-intel
             mountPath: "/data/config"
+          - name: zeek-live-logs-volume
+            mountPath: "/zeek-live-logs"
           - name: zeek-live-zeek-volume
-            mountPath: "/data/zeek-logs"
+            mountPath: "/data/zeek-shared"
       volumes:
         - name: zeek-live-var-local-catrust-volume
           configMap:
@@ -108,7 +114,11 @@ spec:
         - name: zeek-live-zeek-volume
           persistentVolumeClaim:
             claimName: zeek-claim
+        - name: zeek-live-logs-volume
+          hostPath:
+            path: "{{ .Values.zeek_live.zeek_log_path }}"
+            type: DirectoryOrCreate
         - name: zeek-live-zeek-intel
           persistentVolumeClaim:
-            claimName: config-claim            
+            claimName: config-claim
 {{- end }}

--- a/chart/templates/21-zeek-live.yml
+++ b/chart/templates/21-zeek-live.yml
@@ -16,15 +16,15 @@ metadata:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: zeek-live-deployment
+  name: zeek-live-daemonset
 spec:
   selector:
     matchLabels:
-      name: zeek-live-deployment
+      name: zeek-live-daemonset
   template:
     metadata:
       labels:
-        name: zeek-live-deployment
+        name: zeek-live-daemonset
     spec:
       # Required for coredns to work with hostnetwork set to true.
       dnsPolicy: ClusterFirstWithHostNet
@@ -110,5 +110,5 @@ spec:
             claimName: zeek-claim
         - name: zeek-live-zeek-intel
           persistentVolumeClaim:
-            claimName: config-claim
+            claimName: config-claim            
 {{- end }}

--- a/chart/templates/22-suricata-live.yml
+++ b/chart/templates/22-suricata-live.yml
@@ -89,6 +89,7 @@ spec:
           configMap:
             name: var-local-catrust
         - name: suricata-live-suricata-logs-volume
-          persistentVolumeClaim:
-            claimName: suricata-claim
+          hostPath:
+            path: "{{ .Values.suricata_live.suricata_log_path }}"
+            type: DirectoryOrCreate
 {{- end }}

--- a/chart/templates/22-suricata-live.yml
+++ b/chart/templates/22-suricata-live.yml
@@ -13,15 +13,15 @@ metadata:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: suricata-live-deployment
+  name: suricata-live-daemonset
 spec:
   selector:
     matchLabels:
-      name: suricata-live-deployment
+      name: suricata-live-daemonset
   template:
     metadata:
       labels:
-        name: suricata-live-deployment
+        name: suricata-live-daemonset
     spec:
       # Required for coredns to work with hostnetwork set to true.
       dnsPolicy: ClusterFirstWithHostNet

--- a/chart/templates/malcolm_configmaps.yaml
+++ b/chart/templates/malcolm_configmaps.yaml
@@ -135,8 +135,8 @@ data:
   PCAP_FILTER: "{{ .Values.pcap_capture_env.pcap_filter }}"
   PCAP_IFACE: "{{ .Values.pcap_capture_env.pcap_iface }}"
   PCAP_IFACE_TWEAK: "false"
-  PCAP_ROTATE_MEGABYTES: "4096"
-  PCAP_ROTATE_MINUTES: "10"
+  PCAP_ROTATE_MEGABYTES: "{{ .Values.pcap_capture_env.pcap_rotate_megabytes }}"
+  PCAP_ROTATE_MINUTES: "{{ .Values.pcap_capture_env.pcap_rotate_minutes }}"
 kind: ConfigMap
 metadata:
   name: pcap-capture-env
@@ -167,6 +167,7 @@ data:
   SURICATA_UPDATE_DEBUG: "false"
   SURICATA_UPDATE_ETOPEN: "true"
   SURICATA_UPDATE_RULES: "false"
+  SURICATA_HOME_NET: "'{{ .Values.pcap_capture_env.home_net }}'"
 kind: ConfigMap
 metadata:
   name: suricata-env
@@ -204,8 +205,8 @@ data:
   EXTRACTED_FILE_HTTP_SERVER_ENABLE: "{{ .Values.zeek_env.extracted_file_http_server_enable }}"
   EXTRACTED_FILE_HTTP_SERVER_ENCRYPT: "{{ .Values.zeek_env.extracted_file_http_server_encrypt }}"
   EXTRACTED_FILE_IGNORE_EXISTING: "false"
-  EXTRACTED_FILE_MAX_BYTES: "134217728"
-  EXTRACTED_FILE_MIN_BYTES: "64"
+  EXTRACTED_FILE_MAX_BYTES: "{{ .Values.zeek_env.extracted_file_max_bytes }}"
+  EXTRACTED_FILE_MIN_BYTES: "{{ .Values.zeek_env.extracted_file_min_bytes }}"
   EXTRACTED_FILE_PIPELINE_VERBOSITY: ""
   EXTRACTED_FILE_PRESERVATION: {{ .Values.zeek_env.extracted_file_preservation }}
   EXTRACTED_FILE_UPDATE_RULES: "false"

--- a/chart/templates/nginx_configmap.yml
+++ b/chart/templates/nginx_configmap.yml
@@ -23,6 +23,8 @@ data:
       fastcgi_busy_buffers_size 384k;
       fastcgi_request_buffering off;
 
+      # Needed so istio side car containers work with nginx appropriatley
+      proxy_http_version 1.1;
       proxy_connect_timeout 180s;
       proxy_read_timeout 300s;
       proxy_send_timeout 300s;

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/idaholab/malcolm
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion found in Chart.yml.
   tag: ""
 
@@ -12,13 +12,13 @@ auth:
   htpass_cred: "ubuntu:$2y$05$OihKMwCAuOYj6vKGpemeVeHAoup60XOcVzFqKCQ.OHqKmRNZMp0Qy"
 
 opensearch:
-  enabled: false
+  enabled: true
   java_memory: -Xms16g -Xmx16g -Xss256k -XX
   url: http://opensearch:9200
   dashboards_url: http://dashboards:5601/dashboards
 
 external_elasticsearch:
-  enabled: true
+  enabled: false
   url: http://dataplane-ek-es-http.dataplane-ek.svc.cluster.local:9200
   username: "elastic"
   password: ""
@@ -92,7 +92,7 @@ istio:
 # If you disable it, you will still be able to upload pcaps using the malcolm offline upload of pcaps functionality.
 suricata_live:
   enabled: true
-
+  suricata_log_path: /opt/suricata/logs
   # Suricata live is a Daemonset but it will only schedule on kubernetes nodes that has following label
   nodeSelector:
     cnaps.io/suricata-capture: "true"
@@ -102,6 +102,7 @@ suricata_live:
 # If you disable it, you will still be able to upload pcaps using the malcolm offline upload of pcaps functionality.
 zeek_live:
   enabled: true
+  zeek_log_path: /opt/zeek/logs
 
   # Zeek live is a Daemonset but it will only schedule on kubernetes nodes that has following label
   nodeSelector:
@@ -116,6 +117,8 @@ zeek_env:
   extracted_file_http_server_enable: true
   extracted_file_http_server_encrypt: true
   extracted_file_preservation: quarantined
+  extracted_file_max_bytes: "134217728"
+  extracted_file_min_bytes: "64"
 
 
 pcap_live:
@@ -133,6 +136,9 @@ pcap_capture_env:
   # NOTE Net Sniff and tcpdump cannot be both true. Only one or the other can be running at a time.
   net_sniff: false
   tcpdump: true
+  pcap_rotate_megabytes: 4096
+  pcap_rotate_minutes: 10
+  home_net: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
 
 
 # Shared settings across all live capture type things (IE: Zeek live, Suricata live, and Pcap capture)
@@ -148,6 +154,28 @@ live_capture:
     operator: "Equal"
     value: "noncore"
     effect: "NoSchedule"
+
+# Filebeat capture
+filebeat:
+  filebeat_clean_inactive: 180m  
+  filebeat_close_inactive: 120s
+  filebeat_close_inactive_live: 90m
+  filebeat_ignore_older: 120m
+  filebeat_scan_frequency: 10s
+
+# Default affinity ensures that the filebeat Daemonset is applied with anything that also has suricata or zeek live capture running on it.
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: cnaps.io/suricata-capture
+          operator: In
+          values:
+          - "true"
+        - key: cnaps.io/zeek-capture
+          operator: In
+          values:
+          - "true"
 
 # Sets GID and UID for each container
 process_env:


### PR DESCRIPTION
* Created filebeat daemonset to process live files via hostpath instead of using shared storage for performance reasons.

* Added labels and needed annotation

* Reverted annotation and label

* Added more variables

* Bug fix

* Fixed another bug fix with flux helm release. All pvcs must be used otherise the chart never reconciles.

* Added home_net variable

* Added single quotes so homenet will take

* Bugfix so istio side car containers work with nginx