### PR TITLE
Performance tuning and Malcolm Upgrade

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,7 +84,7 @@ Vagrant.configure("2") do |config|
     read -ra my_hostips <<< $myip_string
     cp /vagrant/vagrant_dependencies/Corefile.yaml /tmp/Corefile.yaml
     sed -i "s/###NODE_IP_ADDRESS###/${my_hostips[0]}/g" /tmp/Corefile.yaml
-    kubectl apply -f /tmp/Corefile.yaml
+    kubectl replace -f /tmp/Corefile.yaml
     sleep 5
     echo "Rebooting the VM"
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "24.03.0"
+appVersion: "24.03.1"

--- a/chart/templates/09-dashboards-helper.yml
+++ b/chart/templates/09-dashboards-helper.yml
@@ -87,6 +87,25 @@ spec:
           timeoutSeconds: 15
           successThreshold: 1
           failureThreshold: 10
+{{- if .Values.siem_env.logstash_override.enabled }}
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - |
+              output=$(curl -sSfk $OPENSEARCH_URL/_cat/component_templates/custom_*)
+              if echo $output | grep -q -E 'custom_zeek' && echo $output | grep -q -E 'custom_suricata' && echo $output | grep -q -E 'custom_arkime' && echo $output | grep -q -E 'custom_zeek_ot'; then
+                  exit 0
+              else
+                  exit 1
+              fi
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 15
+          successThreshold: 1
+          failureThreshold: 10
+{{- end }}
         volumeMounts:
           - mountPath: /var/local/ca-trust/configmap
             name: dashboards-helper-var-local-catrust-volume

--- a/chart/templates/09-dashboards-helper.yml
+++ b/chart/templates/09-dashboards-helper.yml
@@ -36,6 +36,133 @@ kind: ConfigMap
 metadata:
   name: dashboards-env
 
+{{- if .Values.siem_env.logstash_override.enabled }}
+---
+apiVersion: v1
+data:
+  malcolm_template.json: |
+    {
+      "index_patterns" : ["MALCOLM_NETWORK_INDEX_PATTERN_REPLACER"],
+      "composed_of": [
+        "ecs_base",
+        "ecs_ecs",
+        "ecs_event",
+        "ecs_agent",
+        "ecs_client",
+        "ecs_destination",
+        "ecs_error",
+        "ecs_file",
+        "ecs_host",
+        "ecs_http",
+        "ecs_log",
+        "ecs_network",
+        "ecs_process",
+        "ecs_related",
+        "ecs_rule",
+        "ecs_server",
+        "ecs_source",
+        "ecs_threat",
+        "ecs_url",
+        "ecs_vulnerability",
+        "ecs_user_agent",
+        "custom_arkime",
+        "custom_suricata",
+        "custom_zeek",
+        "custom_zeek_ot"
+      ],
+      "template" :{
+        "settings" : {
+          "index" : {
+            "lifecycle.name": "{{ .Values.siem_env.logstash_override.ilm_policy }}",
+            "lifecycle.rollover_alias": "{{ .Values.siem_env.logstash_override.rollover_alias }}",
+            "mapping.total_fields.limit" : "5000",
+            "mapping.nested_fields.limit" : "250",
+            "max_docvalue_fields_search" : "200"
+          }
+        },
+        "mappings": {
+          "properties": {
+            "destination.ip_reverse_dns": { "type": "keyword" },
+            "destination.oui": { "type": "keyword" },
+            "destination.device": {
+              "properties": {
+                "cluster": { "type": "keyword" },
+                "device_type": { "type": "keyword" },
+                "id": { "type": "integer" },
+                "manufacturer": { "type": "keyword" },
+                "name": { "type": "keyword" },
+                "role": { "type": "keyword" },
+                "service": { "type": "keyword" },
+                "site": { "type": "keyword" },
+                "url": { "type": "keyword" },
+                "details": { "type": "nested" }
+              }
+            },
+            "destination.segment": {
+              "properties": {
+                "id": { "type": "integer" },
+                "name": { "type": "keyword" },
+                "site": { "type": "keyword" },
+                "tenant": { "type": "keyword" },
+                "url": { "type": "keyword" },
+                "details": { "type": "nested" }
+              }
+            },
+            "event.freq_score_v1": { "type": "float" },
+            "event.freq_score_v2": { "type": "float" },
+            "event.hits": { "type": "long" },
+            "event.result": { "type": "keyword" },
+            "event.severity_tags": { "type": "keyword" },
+            "file.source": { "type": "keyword" },
+            "network.is_orig": { "type": "keyword" },
+            "network.protocol_version": { "type": "keyword" },
+            "related.mac": { "type": "keyword" },
+            "related.oui": { "type": "keyword" },
+            "related.password": { "type": "keyword", "ignore_above": 256, "fields": { "text": { "type": "text" } } },
+            "related.device_id": { "type": "integer" },
+            "related.device_name": { "type": "keyword" },
+            "related.device_type": { "type": "keyword" },
+            "related.manufacturer": { "type": "keyword" },
+            "related.role": { "type": "keyword" },
+            "related.service": { "type": "keyword" },
+            "related.site": { "type": "keyword" },
+            "source.ip_reverse_dns": { "type": "keyword" },
+            "source.oui": { "type": "keyword" },
+            "source.device": {
+              "properties": {
+                "cluster": { "type": "keyword" },
+                "device_type": { "type": "keyword" },
+                "id": { "type": "integer" },
+                "manufacturer": { "type": "keyword" },
+                "name": { "type": "keyword" },
+                "role": { "type": "keyword" },
+                "service": { "type": "keyword" },
+                "site": { "type": "keyword" },
+                "url": { "type": "keyword" },
+                "details": { "type": "nested" }
+              }
+            },
+            "source.segment": {
+              "properties": {
+                "id": { "type": "integer" },
+                "name": { "type": "keyword" },
+                "site": { "type": "keyword" },
+                "tenant": { "type": "keyword" },
+                "url": { "type": "keyword" },
+                "details": { "type": "nested" }
+              }
+            },
+            "tls.client.ja3_description": { "type": "keyword", "ignore_above": 1024, "fields": { "text": { "type": "text" } } },
+            "tls.server.ja3s_description": { "type": "keyword", "ignore_above": 1024, "fields": { "text": { "type": "text" } } }
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: malcolm-template-override
+{{- end }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -87,30 +214,16 @@ spec:
           timeoutSeconds: 15
           successThreshold: 1
           failureThreshold: 10
-{{- if .Values.siem_env.logstash_override.enabled }}
-        readinessProbe:
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              output=$(curl -sSfk $OPENSEARCH_URL/_cat/component_templates/custom_*)
-              if echo $output | grep -q -E 'custom_zeek' && echo $output | grep -q -E 'custom_suricata' && echo $output | grep -q -E 'custom_arkime' && echo $output | grep -q -E 'custom_zeek_ot'; then
-                  exit 0
-              else
-                  exit 1
-              fi
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 15
-          successThreshold: 1
-          failureThreshold: 10
-{{- end }}
         volumeMounts:
           - mountPath: /var/local/ca-trust/configmap
             name: dashboards-helper-var-local-catrust-volume
           - mountPath: /var/local/curlrc/secretmap
             name: dashboards-helper-opensearch-curlrc-secret-volume
+{{- if .Values.siem_env.logstash_override.enabled }}
+          - mountPath: /opt/templates/malcolm_template.json
+            name: malcolm-template-override
+            subPath: malcolm_template.json
+{{- end }}
       volumes:
         - name: dashboards-helper-var-local-catrust-volume
           configMap:
@@ -118,3 +231,8 @@ spec:
         - name: dashboards-helper-opensearch-curlrc-secret-volume
           secret:
             secretName: opensearch-curlrc
+{{- if .Values.siem_env.logstash_override.enabled }}
+        - name: malcolm-template-override
+          configMap:
+            name: malcolm-template-override
+{{- end }}

--- a/chart/templates/10-zeek.yml
+++ b/chart/templates/10-zeek.yml
@@ -87,7 +87,7 @@ spec:
             name: zeek-offline-zeek-volume
             subPath: "upload"
           - mountPath: "/opt/zeek/share/zeek/site/custom/configmap"
-            name: zeek-offline-custom-volume
+            name: zeek-custom-volume
           - mountPath: "/opt/zeek/share/zeek/site/intel-preseed/configmap"
             name: zeek-offline-intel-preseed-volume
           - mountPath: "/opt/zeek/share/zeek/site/intel"
@@ -129,7 +129,7 @@ spec:
         - name: zeek-offline-zeek-volume
           persistentVolumeClaim:
             claimName: zeek-claim
-        - name: zeek-offline-custom-volume
+        - name: zeek-custom-volume
           configMap:
             name: zeek-custom
         - name: zeek-offline-intel-preseed-volume

--- a/chart/templates/10-zeek.yml
+++ b/chart/templates/10-zeek.yml
@@ -36,8 +36,9 @@ spec:
       labels:
         name: zeek-offline-deployment
     spec:
+      serviceAccountName: {{ .Values.zeek_chart_overrides.serviceAccountName | default "default" }}
       containers:
-      - name: zeek-offline-container
+      - name: zeek-container
         image: "{{ $image }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         stdin: false
@@ -72,6 +73,9 @@ spec:
           successThreshold: 1
           failureThreshold: 10
         volumeMounts:
+          {{- if ne (len .Values.zeek_chart_overrides.volumeMounts) 0 }}
+          {{- toYaml .Values.zeek_chart_overrides.volumeMounts | nindent 10 }}
+          {{- else }}
           - mountPath: /var/local/ca-trust/configmap
             name: zeek-offline-var-local-catrust-volume
           - mountPath: "/pcap"
@@ -82,15 +86,17 @@ spec:
           - mountPath: "/zeek/upload"
             name: zeek-offline-zeek-volume
             subPath: "upload"
-          {{- if not .Values.rule_mount_override.enabled }}
           - mountPath: "/opt/zeek/share/zeek/site/custom/configmap"
             name: zeek-offline-custom-volume
-          {{- end }}
           - mountPath: "/opt/zeek/share/zeek/site/intel-preseed/configmap"
             name: zeek-offline-intel-preseed-volume
           - mountPath: "/opt/zeek/share/zeek/site/intel"
             name: zeek-offline-intel-volume
             subPath: "zeek/intel"
+          {{- end }}
+      {{- if ne (len .Values.zeek_chart_overrides.sideCars) 0 }}
+      {{- toYaml .Values.zeek_chart_overrides.sideCars | nindent 6 }}
+      {{- end }}
       initContainers:
       - name: zeek-offline-dirinit-container
         image: "{{ .Values.image.repository }}/dirinit:{{ .Values.image.dirinit_tag | default .Chart.AppVersion }}"
@@ -111,6 +117,9 @@ spec:
           - name: zeek-offline-zeek-volume
             mountPath: "/data/zeek-logs"
       volumes:
+        {{- if ne (len .Values.zeek_chart_overrides.volumes) 0 }}
+        {{- toYaml .Values.zeek_chart_overrides.volumes | nindent 8 }}
+        {{- else }}
         - name: zeek-offline-var-local-catrust-volume
           configMap:
             name: var-local-catrust
@@ -120,14 +129,13 @@ spec:
         - name: zeek-offline-zeek-volume
           persistentVolumeClaim:
             claimName: zeek-claim
-        {{- if not .Values.rule_mount_override.enabled }}
         - name: zeek-offline-custom-volume
           configMap:
             name: zeek-custom
-        {{- end }}
         - name: zeek-offline-intel-preseed-volume
           configMap:
             name: zeek-intel-preseed
         - name: zeek-offline-intel-volume
           persistentVolumeClaim:
             claimName: config-claim
+        {{- end }}

--- a/chart/templates/11-suricata.yml
+++ b/chart/templates/11-suricata.yml
@@ -33,8 +33,9 @@ spec:
       labels:
         name: suricata-offline-deployment
     spec:
+      serviceAccountName: {{ .Values.suricata_chart_overrides.serviceAccountName | default "default" }}
       containers:
-      - name: suricata-offline-container
+      - name: suricata-container
         image: "{{ .Values.image.repository }}/suricata:{{ .Values.image.suricata_tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         stdin: false
@@ -67,18 +68,23 @@ spec:
           successThreshold: 1
           failureThreshold: 10
         volumeMounts:
+          {{- if ne (len .Values.suricata_chart_overrides.volumeMounts) 0 }}
+          {{- toYaml .Values.suricata_chart_overrides.volumeMounts | nindent 10 }}
+          {{- else }}
           - mountPath: /var/local/ca-trust/configmap
             name: suricata-offline-var-local-catrust-volume
           - mountPath: "/data/pcap"
             name: suricata-offline-pcap-volume
           - mountPath: "/var/log/suricata"
             name: suricata-offline-suricata-logs-volume
-          {{- if not .Values.rule_mount_override.enabled }}
           - mountPath: "/opt/suricata/rules/configmap"
-            name: suricata-offline-custom-rules-volume
+            name: suricata-custom-rules-volume
           - mountPath: "/opt/suricata/include-configs/configmap"
-            name: suricata-offline-custom-configs-volume
+            name: suricata-custom-configs-volume
           {{- end }}
+      {{- if ne (len .Values.suricata_chart_overrides.sideCars) 0 }}
+      {{- toYaml .Values.suricata_chart_overrides.sideCars | nindent 6 }}
+      {{- end }}
       initContainers:
       - name: suricata-offline-dirinit-container
         image: "{{ .Values.image.repository }}/dirinit:{{ .Values.image.dirinit_tag | default .Chart.AppVersion }}"
@@ -95,6 +101,9 @@ spec:
           - name: suricata-offline-pcap-volume
             mountPath: "/data/pcap"
       volumes:
+        {{- if ne (len .Values.suricata_chart_overrides.volumes) 0 }}
+        {{- toYaml .Values.suricata_chart_overrides.volumes | nindent 8 }}
+        {{- else }}
         - name: suricata-offline-var-local-catrust-volume
           configMap:
             name: var-local-catrust
@@ -104,11 +113,10 @@ spec:
         - name: suricata-offline-suricata-logs-volume
           persistentVolumeClaim:
             claimName: suricata-claim-offline
-        {{- if not .Values.rule_mount_override.enabled }}
-        - name: suricata-offline-custom-rules-volume
+        - name: suricata-custom-rules-volume
           configMap:
             name: suricata-rules
-        - name: suricata-offline-custom-configs-volume
+        - name: suricata-custom-configs-volume
           configMap:
             name: suricata-configs
         {{- end }}

--- a/chart/templates/13-filebeat.yml
+++ b/chart/templates/13-filebeat.yml
@@ -10,6 +10,8 @@ data:
   FILEBEAT_CLOSE_RENAMED: "true"
   FILEBEAT_IGNORE_OLDER: {{ .Values.filebeat.filebeat_ignore_older }}
   FILEBEAT_SCAN_FREQUENCY: {{ .Values.filebeat.filebeat_scan_frequency }}
+  ZIP_CLEANUP_MINUTES: "{{ .Values.filebeat.zip_cleanup_minutes }}"
+  LOG_CLEANUP_MINUTES: "{{ .Values.filebeat.log_cleanup_minutes }}"
   FILEBEAT_TCP_LISTEN: "true"
   FILEBEAT_TCP_LOG_FORMAT: json
   FILEBEAT_TCP_PARSE_DROP_FIELD: message

--- a/chart/templates/14-logstash.yml
+++ b/chart/templates/14-logstash.yml
@@ -1,13 +1,8 @@
 ---
 apiVersion: v1
 data:
-  LOGSTASH_NETBOX_AUTO_POPULATE: "{{ .Values.netbox.netbox_auto_populate }}"
-  # Whether or not Logstash will enrich network traffic metadata via NetBox API calls
-  LOGSTASH_NETBOX_ENRICHMENT: "{{ .Values.netbox.enabled }}"
   # Which types of logs will be enriched via NetBox (comma-separated list of provider.dataset, or the string all to enrich all logs)
   LOGSTASH_NETBOX_ENRICHMENT_DATASETS: "suricata.alert,zeek.conn,zeek.known_hosts,zeek.known_services,zeek.notice,zeek.signatures,zeek.software,zeek.weird"
-  LOGSTASH_NETBOX_CACHE_SIZE: "1000"
-  LOGSTASH_NETBOX_CACHE_TTL: "30"
   # Zeek log types that will be ignored (dropped) by LogStash
   # Defaults are: analyzer,broker,bsap_ip_unknown,bsap_serial_unknown,capture_loss,cluster,config,ecat_arp_info,loaded_scripts,packet_filter,png,print,prof,reporter,stats,stderr,stdout
   LOGSTASH_ZEEK_IGNORED_LOGS: "bsap_ip_unknown,bsap_serial_unknown,ecat_arp_info,loaded_scripts,png,stderr,stdout"

--- a/chart/templates/14-logstash.yml
+++ b/chart/templates/14-logstash.yml
@@ -62,6 +62,40 @@ spec:
   selector:
     name: logstash-deployment
 
+{{- if .Values.siem_env.logstash_override.enabled }}
+---
+apiVersion: v1
+data:
+  99_opensearch_output.conf: |
+    output {
+      if [event][kind] == "metric" {
+        elasticsearch {
+          id => "output_opensearch_malcolm_metrics"
+          hosts => "${OPENSEARCH_URL:http://opensearch:9200}"
+          ssl_certificate_verification => "false"
+          manage_template => false
+          index => "%{[@metadata][malcolm_opensearch_index]}"
+          document_id => "%{+YYMMdd}-%{[event][hash]}"
+        }
+      } else {
+        elasticsearch {
+          id => "output_opensearch_malcolm"
+          hosts => "${OPENSEARCH_URL:http://opensearch:9200}"
+          ssl_certificate_verification => "false"
+          manage_template => false
+          document_id => "%{+YYMMdd}-%{[event][hash]}"
+          ilm_rollover_alias => "{{ .Values.siem_env.logstash_override.rollover_alias }}"
+          ilm_pattern => "000001"
+          ilm_policy => "{{ .Values.siem_env.logstash_override.ilm_policy }}"
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: elastic-output-override
+  namespace: malcolm
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -149,6 +183,11 @@ spec:
           - name: logstash-config-persist-volume
             mountPath: /usr/share/logstash/config/persist
             subPath: "logstash"
+{{- if .Values.siem_env.logstash_override.enabled }}
+          - mountPath: /usr/share/logstash/malcolm-pipelines/output/99_opensearch_output.conf
+            name: elastic-output-override
+            subPath: 99_opensearch_output.conf
+{{- end }}
       initContainers:
       - name: logstash-dirinit-container
         image: "{{ .Values.image.repository }}/dirinit:{{ .Values.image.dirinit_tag | default .Chart.AppVersion }}"
@@ -180,3 +219,8 @@ spec:
         - name: logstash-config-persist-volume
           persistentVolumeClaim:
             claimName: config-claim
+{{- if .Values.siem_env.logstash_override.enabled }}
+        - name: elastic-output-override
+          configMap:
+            name: elastic-output-override
+{{- end }}

--- a/chart/templates/14-logstash.yml
+++ b/chart/templates/14-logstash.yml
@@ -92,9 +92,7 @@ data:
     }
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   name: elastic-output-override
-  namespace: malcolm
 {{- end }}
 ---
 apiVersion: apps/v1

--- a/chart/templates/14-logstash.yml
+++ b/chart/templates/14-logstash.yml
@@ -71,7 +71,7 @@ spec:
   selector:
     matchLabels:
       name: logstash-deployment
-  replicas: {{ include "malcolm.nodeCount" . }}
+  replicas: {{ max 1 (div (include "malcolm.nodeCount" .) 2) }}
   template:
     metadata:
       labels:

--- a/chart/templates/21-zeek-live.yml
+++ b/chart/templates/21-zeek-live.yml
@@ -20,7 +20,6 @@ data:
   ZEEK_AF_PACKET_BUFFER_SIZE: "{{ .zeek_af_packet_buffer_size }}"
   ZEEK_PIN_CPUS_LOGGER: "{{ .zeek_pin_cpus_logger }}"
   ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
-  ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
   ZEEK_PIN_CPUS_PROXY: "{{ .zeek_pin_cpus_proxy }}"
     {{- end }}
   {{- else }}
@@ -30,7 +29,6 @@ data:
   ZEEK_LB_METHOD: "{{ .zeek_lb_method }}"
   ZEEK_AF_PACKET_BUFFER_SIZE: "{{ .zeek_af_packet_buffer_size }}"
   ZEEK_PIN_CPUS_LOGGER: "{{ .zeek_pin_cpus_logger }}"
-  ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
   ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
   ZEEK_PIN_CPUS_PROXY: "{{ .zeek_pin_cpus_proxy }}"
     {{- end }}

--- a/chart/templates/21-zeek-live.yml
+++ b/chart/templates/21-zeek-live.yml
@@ -18,6 +18,10 @@ data:
   WORKER_LB_PROCS: "{{ .worker_lb_procs }}"
   ZEEK_LB_METHOD: "{{ .zeek_lb_method }}"
   ZEEK_AF_PACKET_BUFFER_SIZE: "{{ .zeek_af_packet_buffer_size }}"
+  ZEEK_PIN_CPUS_LOGGER: "{{ .zeek_pin_cpus_logger }}"
+  ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
+  ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
+  ZEEK_PIN_CPUS_PROXY: "{{ .zeek_pin_cpus_proxy }}"
     {{- end }}
   {{- else }}
     {{- with .Values.zeek_live.development }}
@@ -25,6 +29,10 @@ data:
   WORKER_LB_PROCS: "{{ .worker_lb_procs }}"
   ZEEK_LB_METHOD: "{{ .zeek_lb_method }}"
   ZEEK_AF_PACKET_BUFFER_SIZE: "{{ .zeek_af_packet_buffer_size }}"
+  ZEEK_PIN_CPUS_LOGGER: "{{ .zeek_pin_cpus_logger }}"
+  ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
+  ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
+  ZEEK_PIN_CPUS_PROXY: "{{ .zeek_pin_cpus_proxy }}"
     {{- end }}
   {{- end }}
 kind: ConfigMap

--- a/chart/templates/21-zeek-live.yml
+++ b/chart/templates/21-zeek-live.yml
@@ -48,6 +48,7 @@ spec:
         name: zeek-live-daemonset
     spec:
       # Required for coredns to work with hostnetwork set to true.
+      serviceAccountName: {{ .Values.zeek_chart_overrides.serviceAccountName | default "default" }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       nodeSelector:
@@ -55,7 +56,7 @@ spec:
       tolerations:
 {{ toYaml .Values.live_capture.tolerations | indent 6 }}
       containers:
-      - name: zeek-live-container
+      - name: zeek-container
         image: "{{ $image }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         stdin: false
@@ -91,6 +92,9 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
         volumeMounts:
+          {{- if ne (len .Values.zeek_chart_overrides.live_volumeMounts) 0 }}
+          {{- toYaml .Values.zeek_chart_overrides.live_volumeMounts | nindent 10 }}
+          {{- else }}
           - mountPath: /var/local/ca-trust/configmap
             name: zeek-live-var-local-catrust-volume
           - mountPath: "/zeek/extract_files"
@@ -101,15 +105,17 @@ spec:
             subPath: "upload"
           - mountPath: "/zeek-live-logs"
             name: zeek-live-logs-volume
-          {{- if not .Values.rule_mount_override.enabled }}
           - mountPath: "/opt/zeek/share/zeek/site/custom/configmap"
             name: zeek-live-custom-volume
-          {{- end }}
           - mountPath: "/opt/zeek/share/zeek/site/intel-preseed/configmap"
             name: zeek-live-intel-preseed-volume
           - mountPath: "/opt/zeek/share/zeek/site/intel"
             name: zeek-live-intel-volume
             subPath: "zeek/intel"
+          {{- end }}
+      {{- if ne (len .Values.zeek_chart_overrides.sideCars) 0 }}
+      {{- toYaml .Values.zeek_chart_overrides.sideCars | nindent 6 }}
+      {{- end }}
       initContainers:
       - name: zeek-live-dirinit-container
         image: "{{ .Values.image.repository }}/dirinit:{{ .Values.image.dirinit_tag | default .Chart.AppVersion }}"
@@ -130,17 +136,18 @@ spec:
           - name: zeek-live-zeek-volume
             mountPath: "/data/zeek-shared"
       volumes:
+        {{- if ne (len .Values.zeek_chart_overrides.live_volumes) 0 }}
+        {{- toYaml .Values.zeek_chart_overrides.live_volumes | nindent 8 }}
+        {{- else }}
         - name: zeek-live-var-local-catrust-volume
           configMap:
             name: var-local-catrust
         - name: zeek-live-zeek-volume
           persistentVolumeClaim:
             claimName: zeek-claim
-        {{- if not .Values.rule_mount_override.enabled }}
         - name: zeek-live-custom-volume
           configMap:
             name: zeek-custom
-        {{- end }}
         - name: zeek-live-intel-preseed-volume
           configMap:
             name: zeek-intel-preseed
@@ -151,4 +158,5 @@ spec:
           hostPath:
             path: "{{ .Values.zeek_live.zeek_log_path }}"
             type: DirectoryOrCreate
+        {{- end }}
 {{- end }}

--- a/chart/templates/21-zeek-live.yml
+++ b/chart/templates/21-zeek-live.yml
@@ -18,9 +18,6 @@ data:
   WORKER_LB_PROCS: "{{ .worker_lb_procs }}"
   ZEEK_LB_METHOD: "{{ .zeek_lb_method }}"
   ZEEK_AF_PACKET_BUFFER_SIZE: "{{ .zeek_af_packet_buffer_size }}"
-  ZEEK_PIN_CPUS_LOGGER: "{{ .zeek_pin_cpus_logger }}"
-  ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
-  ZEEK_PIN_CPUS_PROXY: "{{ .zeek_pin_cpus_proxy }}"
     {{- end }}
   {{- else }}
     {{- with .Values.zeek_live.development }}
@@ -28,9 +25,6 @@ data:
   WORKER_LB_PROCS: "{{ .worker_lb_procs }}"
   ZEEK_LB_METHOD: "{{ .zeek_lb_method }}"
   ZEEK_AF_PACKET_BUFFER_SIZE: "{{ .zeek_af_packet_buffer_size }}"
-  ZEEK_PIN_CPUS_LOGGER: "{{ .zeek_pin_cpus_logger }}"
-  ZEEK_PIN_CPUS_MANAGER: "{{ .zeek_pin_cpus_manager }}"
-  ZEEK_PIN_CPUS_PROXY: "{{ .zeek_pin_cpus_proxy }}"
     {{- end }}
   {{- end }}
 kind: ConfigMap

--- a/chart/templates/21-zeek-live.yml
+++ b/chart/templates/21-zeek-live.yml
@@ -18,6 +18,7 @@ data:
   WORKER_LB_PROCS: "{{ .worker_lb_procs }}"
   ZEEK_LB_METHOD: "{{ .zeek_lb_method }}"
   ZEEK_AF_PACKET_BUFFER_SIZE: "{{ .zeek_af_packet_buffer_size }}"
+  ZEEK_PIN_CPUS_WORKER_1: "{{ .zeek_pin_cpus_worker_1 }}"
     {{- end }}
   {{- else }}
     {{- with .Values.zeek_live.development }}
@@ -25,6 +26,7 @@ data:
   WORKER_LB_PROCS: "{{ .worker_lb_procs }}"
   ZEEK_LB_METHOD: "{{ .zeek_lb_method }}"
   ZEEK_AF_PACKET_BUFFER_SIZE: "{{ .zeek_af_packet_buffer_size }}"
+  ZEEK_PIN_CPUS_WORKER_1: "{{ .zeek_pin_cpus_worker_1 }}"
     {{- end }}
   {{- end }}
 kind: ConfigMap

--- a/chart/templates/21-zeek-live.yml
+++ b/chart/templates/21-zeek-live.yml
@@ -106,7 +106,7 @@ spec:
           - mountPath: "/zeek-live-logs"
             name: zeek-live-logs-volume
           - mountPath: "/opt/zeek/share/zeek/site/custom/configmap"
-            name: zeek-live-custom-volume
+            name: zeek-custom-volume
           - mountPath: "/opt/zeek/share/zeek/site/intel-preseed/configmap"
             name: zeek-live-intel-preseed-volume
           - mountPath: "/opt/zeek/share/zeek/site/intel"
@@ -145,7 +145,7 @@ spec:
         - name: zeek-live-zeek-volume
           persistentVolumeClaim:
             claimName: zeek-claim
-        - name: zeek-live-custom-volume
+        - name: zeek-custom-volume
           configMap:
             name: zeek-custom
         - name: zeek-live-intel-preseed-volume

--- a/chart/templates/22-suricata-live.yml
+++ b/chart/templates/22-suricata-live.yml
@@ -25,6 +25,8 @@ data:
   SURICATA_FTP_MEMCAP: "{{ .ftp_memcap }}"
   SURICATA_STREAM_REASSEMBLY_MEMCAP: "{{ .stream_reassembly_memcap }}"
   SURICATA_FLOW_MEMCAP: "{{ .flow_memcap }}"
+  SURICATA_EVE_THREADED: "{{ .eve_threaded }}"
+  SURICATA_EVE_ROTATE_INTERVAL: "{{ .eve_rotate_interval }}"
   {{- end }}
 {{- else }}
   {{- with .Values.suricata_live.development }}
@@ -37,6 +39,8 @@ data:
   SURICATA_FTP_MEMCAP: "{{ .ftp_memcap }}"
   SURICATA_STREAM_REASSEMBLY_MEMCAP: "{{ .stream_reassembly_memcap }}"
   SURICATA_FLOW_MEMCAP: "{{ .flow_memcap }}"
+  SURICATA_EVE_THREADED: "{{ .eve_threaded }}"
+  SURICATA_EVE_ROTATE_INTERVAL: "{{ .eve_rotate_interval }}"
   {{- end }}
 {{- end }}
 kind: ConfigMap

--- a/chart/templates/22-suricata-live.yml
+++ b/chart/templates/22-suricata-live.yml
@@ -61,6 +61,7 @@ spec:
       labels:
         name: suricata-live-daemonset
     spec:
+      serviceAccountName: {{ .Values.suricata_chart_overrides.serviceAccountName | default "default" }}
       # Required for coredns to work with hostnetwork set to true.
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -69,7 +70,7 @@ spec:
       tolerations:
 {{ toYaml .Values.live_capture.tolerations | indent 6 }}
       containers:
-      - name: suricata-live-container
+      - name: suricata-container
         image: "{{ .Values.image.repository }}/suricata:{{ .Values.image.suricata_tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         stdin: false
@@ -107,16 +108,21 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
         volumeMounts:
+          {{- if ne (len .Values.suricata_chart_overrides.live_volumeMounts) 0 }}
+          {{- toYaml .Values.suricata_chart_overrides.live_volumeMounts | nindent 10 }}
+          {{- else }}
           - mountPath: /var/local/ca-trust/configmap
             name: suricata-live-var-local-catrust-volume
           - mountPath: /var/log/suricata
             name: suricata-live-suricata-logs-volume
-          {{- if not .Values.rule_mount_override.enabled }}
           - mountPath: "/opt/suricata/rules/configmap"
-            name: suricata-live-custom-rules-volume
+            name: suricata-custom-rules-volume
           - mountPath: "/opt/suricata/include-configs/configmap"
-            name: suricata-live-custom-configs-volume
+            name: suricata-custom-configs-volume
           {{- end }}
+      {{- if ne (len .Values.suricata_chart_overrides.sideCars) 0 }}
+      {{- toYaml .Values.suricata_chart_overrides.sideCars | nindent 6 }}
+      {{- end }}
       initContainers:
       - name: suricata-live-dirinit-container
         image: "{{ .Values.image.repository }}/dirinit:{{ .Values.image.dirinit_tag | default .Chart.AppVersion }}"
@@ -133,6 +139,9 @@ spec:
           - name: suricata-live-suricata-logs-volume
             mountPath: "/data/suricata-logs"
       volumes:
+        {{- if ne (len .Values.suricata_chart_overrides.live_volumes) 0 }}
+        {{- toYaml .Values.suricata_chart_overrides.live_volumes | nindent 8 }}
+        {{- else }}
         - name: suricata-live-var-local-catrust-volume
           configMap:
             name: var-local-catrust
@@ -140,11 +149,10 @@ spec:
           hostPath:
             path: "{{ .Values.suricata_live.suricata_log_path }}"
             type: DirectoryOrCreate
-        {{- if not .Values.rule_mount_override.enabled }}
-        - name: suricata-live-custom-rules-volume
+        - name: suricata-custom-rules-volume
           configMap:
             name: suricata-rules
-        - name: suricata-live-custom-configs-volume
+        - name: suricata-custom-configs-volume
           configMap:
             name: suricata-configs
         {{- end }}

--- a/chart/templates/22-suricata-live.yml
+++ b/chart/templates/22-suricata-live.yml
@@ -19,12 +19,24 @@ data:
   SURICATA_AF_PACKET_IFACE_THREADS: "{{ .af_packet_iface_threads }}"
   SURICATA_AF_PACKET_RING_SIZE: "{{ .af_packet_ring_size }}"
   SURICATA_MAX_PENDING_PACKETS: "{{ .max_pending_packets }}"
+  SURICATA_STREAM_MEMCAP: "{{ .stream_memcap }}"
+  SURICATA_HOST_MEMCAP: "{{ .host_memcap }}"
+  SURICATA_DEFRAG_MEMCAP: "{{ .defrag_memcap }}"
+  SURICATA_FTP_MEMCAP: "{{ .ftp_memcap }}"
+  SURICATA_STREAM_REASSEMBLY_MEMCAP: "{{ .stream_reassembly_memcap }}"
+  SURICATA_FLOW_MEMCAP: "{{ .flow_memcap }}"
   {{- end }}
 {{- else }}
   {{- with .Values.suricata_live.development }}
   SURICATA_AF_PACKET_IFACE_THREADS: "{{ .af_packet_iface_threads }}"
   SURICATA_AF_PACKET_RING_SIZE: "{{ .af_packet_ring_size }}"
   SURICATA_MAX_PENDING_PACKETS: "{{ .max_pending_packets }}"
+  SURICATA_STREAM_MEMCAP: "{{ .stream_memcap }}"
+  SURICATA_HOST_MEMCAP: "{{ .host_memcap }}"
+  SURICATA_DEFRAG_MEMCAP: "{{ .defrag_memcap }}"
+  SURICATA_FTP_MEMCAP: "{{ .ftp_memcap }}"
+  SURICATA_STREAM_REASSEMBLY_MEMCAP: "{{ .stream_reassembly_memcap }}"
+  SURICATA_FLOW_MEMCAP: "{{ .flow_memcap }}"
   {{- end }}
 {{- end }}
 kind: ConfigMap

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -166,7 +166,7 @@ opensearch-{{ $index }},
 Generate extra secrets for database
 */}}
 {{- define "netbox.databaseExtravars" }}
-{{- range $index, $value := .netbox.database.extra_secrets }}
+{{- range $index, $value := .Values.netbox.database.extra_secrets }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -178,7 +178,7 @@ data:
         {{- if $value2 }}
   {{ $key1 }}: {{ $value2 | b64enc }}
         {{- else }}
-  {{ $key1 }}: {{ $.postgresPassword | b64enc }}
+  {{ $key1 }}: {{ $.Values.netbox.database.password | b64enc }}
         {{- end }}
     {{- end }}
   {{- end }}

--- a/chart/templates/arkime-ini.yml
+++ b/chart/templates/arkime-ini.yml
@@ -16,7 +16,6 @@ data:
     dropUser=arkime
     elasticsearch={{ include "malcolm.opensearchprimaryurl" . }}
     footerTemplate=_version_ | <a href="https://arkime.com">arkime.com 🦉</a> | <a href="/">Malc⦿lm 📄</a> | <a href="/dashboards/">Dashboards 📊</a> | <a href="/netbox/">NetBox 💻 | _responseTime_ ⏱️</a>
-    freeSpaceG={{ .Values.arkime_env.free_space_g }}
     geoLite2ASN=/opt/arkime/etc/GeoLite2-ASN.mmdb
     geoLite2Country=/opt/arkime/etc/GeoLite2-Country.mmdb
     httpRealm=Arkime
@@ -49,7 +48,17 @@ data:
     readTruncatedPackets=true
     reqBodyOnlyUtf8=true
     rirFile=/opt/arkime/etc/ipv4-address-space.csv
-    rotateIndex={{ .Values.arkime_env.rotate_index }}
+{{- if .Values.is_production }}
+  {{- with .Values.arkime_env.production }}
+    rotateIndex={{ .rotate_index }}
+    freeSpaceG={{ .free_space_g }}
+  {{- end }}
+{{- else }}
+  {{- with .Values.arkime_env.development }}
+    rotateIndex={{ .rotate_index }}
+    freeSpaceG={{ .free_space_g }}
+  {{- end }}
+{{- end }}
     rulesFiles=
     smtpIpHeaders=X-Originating-IP:;X-Barracuda-Apparent-Source-IP:
     spiDataMaxIndices=7

--- a/chart/templates/arkime-ini.yml
+++ b/chart/templates/arkime-ini.yml
@@ -12,8 +12,14 @@ data:
     #certFile=/opt/arkime/etc/viewer.crt
     compressES=false
     cronQueries=true
+    debug={{ .Values.arkime_env.arkime_debug_level }}
     dropGroup=arkime
     dropUser=arkime
+{{- if ne .Values.siem_env.malcolm_network_index_pattern "arkime_sessions3-*" }}
+    queryExtraIndices={{ .Values.siem_env.malcolm_network_index_pattern }}
+{{- else }}
+    queryExtraIndices=
+{{- end }}
     elasticsearch={{ include "malcolm.opensearchprimaryurl" . }}
     footerTemplate=_version_ | <a href="https://arkime.com">arkime.com 🦉</a> | <a href="/">Malc⦿lm 📄</a> | <a href="/dashboards/">Dashboards 📊</a> | <a href="/netbox/">NetBox 💻 | _responseTime_ ⏱️</a>
     geoLite2ASN=/opt/arkime/etc/GeoLite2-ASN.mmdb

--- a/chart/templates/arkime_configmaps.yml
+++ b/chart/templates/arkime_configmaps.yml
@@ -70,6 +70,7 @@ data:
   #   https://arkime.com/faq#pcap-deletion
   MANAGE_PCAP_FILES: "true"
   OPENSEARCH_MAX_SHARDS_PER_NODE: "2500"
+  ARKIME_DEBUG_LEVEL: "{{ .Values.arkime_env.arkime_debug_level }}"
 {{- if .Values.is_production }}
   {{- with .Values.arkime_env.production }}
   ARKIME_FREESPACEG: "{{ .free_space_g }}"

--- a/chart/templates/arkime_configmaps.yml
+++ b/chart/templates/arkime_configmaps.yml
@@ -70,25 +70,31 @@ data:
   #   https://arkime.com/faq#pcap-deletion
   MANAGE_PCAP_FILES: "true"
   OPENSEARCH_MAX_SHARDS_PER_NODE: "2500"
-  ARKIME_FREESPACEG: "{{ .Values.arkime_env.free_space_g }}"
-  # How often to create a new index in OpenSearch/Elasticsearch
-  #   https://arkime.com/settings#rotateIndex
-  ARKIME_ROTATE_INDEX: "{{ .Values.arkime_env.rotate_index }}"
-  # These variables manage setting for Arkime's ILM/ISM features (https://arkime.com/faq#ilm)
-  # Whether or not Arkime should perform index management
-  INDEX_MANAGEMENT_ENABLED: "{{ .Values.arkime_env.index_management_enabled }}"
-  # Time in hours/days before moving to warm and force merge (number followed by h or d)
-  INDEX_MANAGEMENT_OPTIMIZATION_PERIOD: "{{ .Values.arkime_env.index_management_optimization_period }}"
-  # Time in hours/days before deleting index (number followed by h or d)
-  INDEX_MANAGEMENT_RETENTION_TIME: "{{ .Values.arkime_env.index_management_retention_time }}"
-  # Number of replicas for older sessions indices
-  INDEX_MANAGEMENT_OLDER_SESSION_REPLICAS: "{{ .Values.arkime_env.index_management_older_session_replicas }}"
-  # Number of weeks of history to retain
-  INDEX_MANAGEMENT_HISTORY_RETENTION_WEEKS: "{{ .Values.arkime_env.index_management_history_retention_weeks }}"
-  # Number of segments to optimize sessions for
-  INDEX_MANAGEMENT_SEGMENTS: "{{ .Values.arkime_env.index_management_segments }}"
-  # Whether or not Arkime should use a hot/warm design (storing non-session data in a warm index)
-  INDEX_MANAGEMENT_HOT_WARM_ENABLED: "{{ .Values.arkime_env.index_management_hot_warm_enabled }}"
+{{- if .Values.is_production }}
+  {{- with .Values.arkime_env.production }}
+  ARKIME_FREESPACEG: "{{ .free_space_g }}"
+  ARKIME_ROTATE_INDEX: "{{ .rotate_index }}"
+  INDEX_MANAGEMENT_ENABLED: "{{ .index_management_enabled }}"
+  INDEX_MANAGEMENT_OPTIMIZATION_PERIOD: "{{ .index_management_optimization_period }}"
+  INDEX_MANAGEMENT_RETENTION_TIME: "{{ .index_management_retention_time }}"
+  INDEX_MANAGEMENT_OLDER_SESSION_REPLICAS: "{{ .index_management_older_session_replicas }}"
+  INDEX_MANAGEMENT_HISTORY_RETENTION_WEEKS: "{{ .index_management_history_retention_weeks }}"
+  INDEX_MANAGEMENT_SEGMENTS: "{{ .index_management_segments }}"
+  INDEX_MANAGEMENT_HOT_WARM_ENABLED: "{{ .index_management_hot_warm_enabled }}"
+  {{- end }}
+{{- else }}
+  {{- with .Values.arkime_env.development }}
+  ARKIME_FREESPACEG: "{{ .free_space_g }}"
+  ARKIME_ROTATE_INDEX: "{{ .rotate_index }}"
+  INDEX_MANAGEMENT_ENABLED: "{{ .index_management_enabled }}"
+  INDEX_MANAGEMENT_OPTIMIZATION_PERIOD: "{{ .index_management_optimization_period }}"
+  INDEX_MANAGEMENT_RETENTION_TIME: "{{ .index_management_retention_time }}"
+  INDEX_MANAGEMENT_OLDER_SESSION_REPLICAS: "{{ .index_management_older_session_replicas }}"
+  INDEX_MANAGEMENT_HISTORY_RETENTION_WEEKS: "{{ .index_management_history_retention_weeks }}"
+  INDEX_MANAGEMENT_SEGMENTS: "{{ .index_management_segments }}"
+  INDEX_MANAGEMENT_HOT_WARM_ENABLED: "{{ .index_management_hot_warm_enabled }}"
+  {{- end }}
+{{- end }}
 kind: ConfigMap
 metadata:
   name: arkime-env

--- a/chart/templates/malcolm_configmaps.yaml
+++ b/chart/templates/malcolm_configmaps.yaml
@@ -155,29 +155,14 @@ data:
   path.repo: /opt/opensearch/backup
   node.roles: ingest,data,remote_cluster_client,cluster_manager
   discovery.seed_hosts: {{ template "malcolm.discoverySeeds" . }}
-{{- if .Values.is_production }}
-  {{- with .Values.siem_env.production }}
-  MALCOLM_NETWORK_INDEX_PATTERN: "{{ .malcolm_network_index_pattern }}"
-  MALCOLM_NETWORK_INDEX_TIME_FIELD: "{{ .malcolm_network_index_time_field }}"
-  MALCOLM_NETWORK_INDEX_SUFFIX: "{{ .malcolm_network_index_suffix }}"
-  MALCOLM_OTHER_INDEX_PATTERN: "{{ .malcolm_other_index_pattern }}"
-  MALCOLM_OTHER_INDEX_TIME_FIELD: "{{ .malcolm_other_index_time_field }}"
-  MALCOLM_OTHER_INDEX_SUFFIX: "{{ .malcolm_other_index_suffix }}"
-  ARKIME_NETWORK_INDEX_PATTERN: "{{ .arkime_network_index_pattern }}"
-  ARKIME_NETWORK_INDEX_TIME_FIELD: "{{ .arkime_network_index_time_field }}"
-  {{- end }}
-{{- else }}
-  {{- with .Values.siem_env.development }}
-  MALCOLM_NETWORK_INDEX_PATTERN: "{{ .malcolm_network_index_pattern }}"
-  MALCOLM_NETWORK_INDEX_TIME_FIELD: "{{ .malcolm_network_index_time_field }}"
-  MALCOLM_NETWORK_INDEX_SUFFIX: "{{ .malcolm_network_index_suffix }}"
-  MALCOLM_OTHER_INDEX_PATTERN: "{{ .malcolm_other_index_pattern }}"
-  MALCOLM_OTHER_INDEX_TIME_FIELD: "{{ .malcolm_other_index_time_field }}"
-  MALCOLM_OTHER_INDEX_SUFFIX: "{{ .malcolm_other_index_suffix }}"
-  ARKIME_NETWORK_INDEX_PATTERN: "{{ .arkime_network_index_pattern }}"
-  ARKIME_NETWORK_INDEX_TIME_FIELD: "{{ .arkime_network_index_time_field }}"
-  {{- end }}
-{{- end }}
+  MALCOLM_NETWORK_INDEX_PATTERN: "{{ .Values.siem_env.malcolm_network_index_pattern }}"
+  MALCOLM_NETWORK_INDEX_TIME_FIELD: "{{ .Values.siem_env.malcolm_network_index_time_field }}"
+  MALCOLM_NETWORK_INDEX_SUFFIX: "{{ .Values.siem_env.malcolm_network_index_suffix }}"
+  MALCOLM_OTHER_INDEX_PATTERN: "{{ .Values.siem_env.malcolm_other_index_pattern }}"
+  MALCOLM_OTHER_INDEX_TIME_FIELD: "{{ .Values.siem_env.malcolm_other_index_time_field }}"
+  MALCOLM_OTHER_INDEX_SUFFIX: "{{ .Values.siem_env.malcolm_other_index_suffix }}"
+  ARKIME_NETWORK_INDEX_PATTERN: "{{ .Values.siem_env.arkime_network_index_pattern }}"
+  ARKIME_NETWORK_INDEX_TIME_FIELD: "{{ .Values.siem_env.arkime_network_index_time_field }}"
 kind: ConfigMap
 metadata:
   name: opensearch-env

--- a/chart/templates/malcolm_configmaps.yaml
+++ b/chart/templates/malcolm_configmaps.yaml
@@ -35,14 +35,26 @@ metadata:
 apiVersion: v1
 data:
   NETBOX_CRON: "{{ .Values.netbox.enabled }}"
+  # The name of the default "site" to be created upon NetBox initialization, and to be queried for enrichment
   NETBOX_DEFAULT_SITE: "{{ .Values.netbox.netbox_default_site }}"
   # Customize manufacturer matching/creation with LOGSTASH_NETBOX_AUTO_POPULATE (see logstash.env)
   NETBOX_DEFAULT_AUTOCREATE_MANUFACTURER: "true"
   NETBOX_DEFAULT_FUZZY_THRESHOLD: "0.95"
-  NETBOX_PRELOAD_PREFIXES: "{{ .Values.netbox.netbox_auto_populate }}"
   NETBOX_DISABLED: "{{ not .Values.netbox.enabled }}"
   NETBOX_POSTGRES_DISABLED: "{{ not .Values.netbox.enabled }}"
   NETBOX_REDIS_DISABLED: "{{ not .Values.netbox.enabled }}"
+
+  # Whether or not Logstash will enrich network traffic metadata via NetBox API calls
+  NETBOX_ENRICHMENT: "{{ .Values.netbox.enabled }}"
+  # Whether or not unobserved network entities in Logstash data will be used to populate NetBox
+  NETBOX_AUTO_POPULATE: "{{ .Values.netbox.netbox_auto_populate }}"
+  # Whether or not unobserved network subnets in Logstash data will be created automatically in NetBox
+  NETBOX_AUTO_CREATE_PREFIX: "{{ .Values.netbox.netbox_auto_populate }}"
+  # Whether or not services (i.e., destination IP/port) will be looked up during NetBox enrichment
+  NETBOX_ENRICHMENT_LOOKUP_SERVICE: "{{ .Values.netbox.enabled }}"
+  # Customize manufacturer matching/creation with NETBOX_AUTO_POPULATE
+  NETBOX_CACHE_SIZE: "{{ .Values.netbox.netbox_cache_size }}"
+  NETBOX_CACHE_TTL: "{{ .Values.netbox.netbox_cache_ttl }}"
 kind: ConfigMap
 metadata:
   name: netbox-common-env
@@ -218,13 +230,11 @@ metadata:
 apiVersion: v1
 data:
   AUTO_TAG: "true"
-  LOG_CLEANUP_MINUTES: "{{ .Values.upload_common_env.log_cleanup_minutes }}"
   PCAP_MONITOR_HOST: pcap-monitor
   PCAP_PIPELINE_IGNORE_PREEXISTING: "false"
   PCAP_PIPELINE_POLLING: "true"
   PCAP_PIPELINE_POLLING_ASSUME_CLOSED_SEC: "10"
   PCAP_PIPELINE_VERBOSITY: ""
-  ZIP_CLEANUP_MINUTES: "{{ .Values.upload_common_env.zip_cleanup_minutes }}"
 kind: ConfigMap
 metadata:
   name: upload-common-env

--- a/chart/templates/malcolm_configmaps.yaml
+++ b/chart/templates/malcolm_configmaps.yaml
@@ -155,23 +155,29 @@ data:
   path.repo: /opt/opensearch/backup
   node.roles: ingest,data,remote_cluster_client,cluster_manager
   discovery.seed_hosts: {{ template "malcolm.discoverySeeds" . }}
-  # OpenSearch index patterns and timestamp fields
-  # Index pattern for network traffic logs written via Logstash (e.g., Zeek logs, Suricata alerts)
-  MALCOLM_NETWORK_INDEX_PATTERN: "{{ .Values.siem_env.malcolm_network_index_pattern }}"
-  # Default time field to use for network traffic logs in Logstash and Dashboards
-  MALCOLM_NETWORK_INDEX_TIME_FIELD: "{{ .Values.siem_env.malcolm_network_index_time_field }}"
-  # Suffix used to create index to which network traffic logs are written (supports Ruby strftime strings in %{})
-  MALCOLM_NETWORK_INDEX_SUFFIX: "{{ .Values.siem_env.malcolm_network_index_suffix }}"
-  # Index pattern for other logs written via Logstash (e.g., nginx, beats, fluent-bit, etc.)
-  MALCOLM_OTHER_INDEX_PATTERN: "{{ .Values.siem_env.malcolm_other_index_pattern }}"
-  # Default time field to use for other logs in Logstash and Dashboards
-  MALCOLM_OTHER_INDEX_TIME_FIELD: "{{ .Values.siem_env.malcolm_other_index_time_field }}"
-  # Suffix used to create index to which other logs are written (supports Ruby strftime strings in %{})
-  MALCOLM_OTHER_INDEX_SUFFIX: "{{ .Values.siem_env.malcolm_other_index_suffix }}"
-  # Index pattern used specifically by Arkime (will probably match MALCOLM_NETWORK_INDEX_PATTERN, should probably be arkime_sessions3-*)
-  ARKIME_NETWORK_INDEX_PATTERN: "{{ .Values.siem_env.arkime_network_index_pattern }}"
-  # Default time field used by for sessions in Arkime viewer
-  ARKIME_NETWORK_INDEX_TIME_FIELD: "{{ .Values.siem_env.arkime_network_index_time_field }}"
+{{- if .Values.is_production }}
+  {{- with .Values.siem_env.production }}
+  MALCOLM_NETWORK_INDEX_PATTERN: "{{ .malcolm_network_index_pattern }}"
+  MALCOLM_NETWORK_INDEX_TIME_FIELD: "{{ .malcolm_network_index_time_field }}"
+  MALCOLM_NETWORK_INDEX_SUFFIX: "{{ .malcolm_network_index_suffix }}"
+  MALCOLM_OTHER_INDEX_PATTERN: "{{ .malcolm_other_index_pattern }}"
+  MALCOLM_OTHER_INDEX_TIME_FIELD: "{{ .malcolm_other_index_time_field }}"
+  MALCOLM_OTHER_INDEX_SUFFIX: "{{ .malcolm_other_index_suffix }}"
+  ARKIME_NETWORK_INDEX_PATTERN: "{{ .arkime_network_index_pattern }}"
+  ARKIME_NETWORK_INDEX_TIME_FIELD: "{{ .arkime_network_index_time_field }}"
+  {{- end }}
+{{- else }}
+  {{- with .Values.siem_env.development }}
+  MALCOLM_NETWORK_INDEX_PATTERN: "{{ .malcolm_network_index_pattern }}"
+  MALCOLM_NETWORK_INDEX_TIME_FIELD: "{{ .malcolm_network_index_time_field }}"
+  MALCOLM_NETWORK_INDEX_SUFFIX: "{{ .malcolm_network_index_suffix }}"
+  MALCOLM_OTHER_INDEX_PATTERN: "{{ .malcolm_other_index_pattern }}"
+  MALCOLM_OTHER_INDEX_TIME_FIELD: "{{ .malcolm_other_index_time_field }}"
+  MALCOLM_OTHER_INDEX_SUFFIX: "{{ .malcolm_other_index_suffix }}"
+  ARKIME_NETWORK_INDEX_PATTERN: "{{ .arkime_network_index_pattern }}"
+  ARKIME_NETWORK_INDEX_TIME_FIELD: "{{ .arkime_network_index_time_field }}"
+  {{- end }}
+{{- end }}
 kind: ConfigMap
 metadata:
   name: opensearch-env

--- a/chart/templates/malcolm_secrets.yaml
+++ b/chart/templates/malcolm_secrets.yaml
@@ -1,4 +1,3 @@
-{{- $postgresPassword := randAlphaNum 25 }}
 {{- $redisPassword := randAlphaNum 25 }}
 {{- $netboxSuperUserPassword := randAlphaNum 25 }}
 {{- $netboxSecretKey := randAlphaNum 50 }}
@@ -71,7 +70,7 @@ type: Opaque
 apiVersion: v1
 data:
   POSTGRES_DB: {{ "netbox" | b64enc }}
-  POSTGRES_PASSWORD: {{ $postgresPassword | b64enc }}
+  POSTGRES_PASSWORD: {{ .Values.netbox.database.password | b64enc }}
   POSTGRES_USER: {{ "netbox" | b64enc }}
 kind: Secret
 metadata:
@@ -99,7 +98,7 @@ type: Opaque
 ---
 apiVersion: v1
 data:
-  DB_PASSWORD: {{ $postgresPassword | b64enc }}
+  DB_PASSWORD: {{  .Values.netbox.database.password | b64enc }}
   DB_USER: {{ "netbox" | b64enc }}
   EMAIL_PASSWORD: ""
   EMAIL_USERNAME: {{ "netbox" | b64enc }}
@@ -139,5 +138,5 @@ type: Opaque
 
 ---
 {{- if .Values.netbox.database.is_custom }}
-{{- include "netbox.databaseExtravars" (dict "netbox" .Values.netbox "postgresPassword" $postgresPassword) }}
+{{- include "netbox.databaseExtravars" . }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -371,7 +371,7 @@ arkime_live:
   enabled: true
   pcap_hostpath: "/zpool/nta-pcap"
   development:
-    arkime_compression_type: none
+    arkime_compression_type: zstd
     arkime_compression_level: "0"
     arkime_db_bulk_size: "4000000"
     arkime_max_packets_in_queue: "300000"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -267,11 +267,19 @@ zeek_live:
     worker_lb_procs: "1"
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "67108864"
+    zeek_pin_cpus_logger: ""
+    zeek_pin_cpus_manager: ""
+    zeek_pin_cpus_manager: ""
+    zeek_pin_cpus_proxy: ""
   production:
     zeek_lb_procs: "24"
     worker_lb_procs: "24"
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "134217728"
+    zeek_pin_cpus_logger: ""
+    zeek_pin_cpus_manager: ""
+    zeek_pin_cpus_manager: ""
+    zeek_pin_cpus_proxy: ""
 
 
 # Only affects the zeek offline deployment

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -270,8 +270,8 @@ zeek_live:
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "67108864"
   production:
-    zeek_lb_procs: "12"
-    worker_lb_procs: "12"
+    zeek_lb_procs: "24"
+    worker_lb_procs: "24"
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "134217728"
 
@@ -370,9 +370,9 @@ arkime_live:
     arkime_compression_level: "3"
     arkime_db_bulk_size: "4000000"
     arkime_max_packets_in_queue: "300000"
-    arkime_packet_threads: "8"
+    arkime_packet_threads: "16"
     arkime_pcap_write_size: "2560000"
-    arkime_tpacketv3_num_threads: "8"
+    arkime_tpacketv3_num_threads: "16"
     arkime_tpacketv3_block_size: "8388608"
 
   # Arkime live is a Daemonset but it will only schedule on kubernetes nodes that has following label

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -233,6 +233,12 @@ suricata_live:
     af_packet_iface_threads: 2
     af_packet_ring_size: 2048
     max_pending_packets: 1024
+    stream_memcap: "64mb"
+    host_memcap: "32mb"
+    defrag_memcap: "32mb"
+    ftp_memcap: "64mb"
+    stream_reassembly_memcap: "256mb"
+    flow_memcap: "128mb"
     # Used if is production is set to true
   production:
     af_packet_iface_threads: 32
@@ -240,6 +246,12 @@ suricata_live:
     # This calculation was made with the assumtion that max-pending-packets is set to 1024
     af_packet_ring_size: 131072
     max_pending_packets: 8192
+    stream_memcap: "16gb"
+    host_memcap: "32mb"
+    defrag_memcap: "16gb"
+    ftp_memcap: "4gb"
+    stream_reassembly_memcap: "16gb"
+    flow_memcap: "16gb"
 
 dashboards_helper_env:
   opensearch_index_size_prune_limit: 0
@@ -267,11 +279,13 @@ zeek_live:
     worker_lb_procs: "1"
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "67108864"
+    zeek_pin_cpus_worker_1: "1"
   production:
     zeek_lb_procs: "24"
     worker_lb_procs: "24"
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "134217728"
+    zeek_pin_cpus_worker_1: "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"
 
 
 # Only affects the zeek offline deployment

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -86,21 +86,33 @@ external_elasticsearch:
 siem_env:
   # OpenSearch index patterns and timestamp fields
   # Index pattern for network traffic logs written via Logstash (e.g., Zeek logs, Suricata alerts)
-  malcolm_network_index_pattern: "arkime_sessions3-*"
-  # Default time field to use for network traffic logs in Logstash and Dashboards
-  malcolm_network_index_time_field: "firstPacket"
-  # Suffix used to create index to which network traffic logs are written (supports Ruby strftime strings in %{})
-  malcolm_network_index_suffix: "%{%y%m%d}"
-  # Index pattern for other logs written via Logstash (e.g., nginx, beats, fluent-bit, etc.)
-  malcolm_other_index_pattern: "malcolm_beats_*"
-  # Default time field to use for other logs in Logstash and Dashboards
-  malcolm_other_index_time_field: "@timestamp"
-  # Suffix used to create index to which other logs are written (supports Ruby strftime strings in %{})
-  malcolm_other_index_suffix: "%{%y%m%d}"
-  # Index pattern used specifically by Arkime (will probably match MALCOLM_NETWORK_INDEX_PATTERN, should probably be arkime_sessions3-*)
-  arkime_network_index_pattern: "arkime_sessions3-*"
-  # Default time field used by for sessions in Arkime viewer
-  arkime_network_index_time_field: "firstPacket"
+  development:
+    malcolm_network_index_pattern: "arkime_sessions3-*"
+    # Default time field to use for network traffic logs in Logstash and Dashboards
+    malcolm_network_index_time_field: "firstPacket"
+    # Suffix used to create index to which network traffic logs are written (supports Ruby strftime strings in %{})
+    # e.g., hourly: %{%y%m%dh%H}, daily: %{%y%m%d}, weekly: %{%yw%U}, monthly: %{%ym%m}
+    malcolm_network_index_suffix: "%{%y%m%d}"
+    # Index pattern for other logs written via Logstash (e.g., nginx, beats, fluent-bit, etc.)
+    malcolm_other_index_pattern: "malcolm_beats_*"
+    # Default time field to use for other logs in Logstash and Dashboards
+    malcolm_other_index_time_field: "@timestamp"
+    # Suffix used to create index to which other logs are written (supports Ruby strftime strings in %{})
+    malcolm_other_index_suffix: "%{%y%m%d}"
+    # Index pattern used specifically by Arkime (will probably match MALCOLM_NETWORK_INDEX_PATTERN, should probably be arkime_sessions3-*)
+    arkime_network_index_pattern: "arkime_sessions3-*"
+    # Default time field used by for sessions in Arkime viewer
+    arkime_network_index_time_field: "firstPacket"
+  production:
+    malcolm_network_index_pattern: "arkime_sessions3-*"
+    malcolm_network_index_time_field: "firstPacket"
+    malcolm_network_index_suffix: "%{%y%m%dh%H}"
+    malcolm_other_index_pattern: "malcolm_beats_*"
+    malcolm_other_index_time_field: "@timestamp"
+    malcolm_other_index_suffix: "%{%y%m%d}"
+    arkime_network_index_pattern: "arkime_sessions3-*"
+    arkime_network_index_time_field: "firstPacket"
+
 
 logstash:
   # Note the number of logstash instances will be based on the number of nodes in your kubernetes cluster.
@@ -290,7 +302,7 @@ zeek_env:
   # `mapped`: extraction of files with recognized mime types
   # `known`: extraction of files for which any mime type can be determined
   # `all`: extract all files
-  extract_mode: notcommtxt
+  extract_mode: interesting
   extracted_file_enable_capa: true
   extracted_file_enable_clamav: true
   extracted_file_enable_yara: true
@@ -312,23 +324,34 @@ zeek_env:
 
 # Variables apply to both offline and live version of arkime
 arkime_env:
-  free_space_g: "10%"
-  rotate_index: hourly6
-  # These variables manage setting for Arkime's ILM/ISM features (https://arkime.com/faq#ilm)
-  # Whether or not Arkime should perform index management
-  index_management_enabled: "false"
-  # Time in hours/days before moving to warm and force merge (number followed by h or d)
-  index_management_optimization_period: "30d"
-  # Time in hours/days before deleting index (number followed by h or d)
-  index_management_retention_time: "90d"
-  # Number of replicas for older sessions indices
-  index_management_older_session_replicas: "0"
-  # Number of weeks of history to retain
-  index_management_history_retention_weeks: "13"
-  # Number of segments to optimize sessions for
-  index_management_segments: "1"
-  # Whether or not Arkime should use a hot/warm design (storing non-session data in a warm index)
-  index_management_hot_warm_enabled: "false"
+  development:
+    free_space_g: "10%"
+    rotate_index: daily
+    # These variables manage setting for Arkime's ILM/ISM features (https://arkime.com/faq#ilm)
+    # Whether or not Arkime should perform index management
+    index_management_enabled: "false"
+    # Time in hours/days before moving to warm and force merge (number followed by h or d)
+    index_management_optimization_period: "30d"
+    # Time in hours/days before deleting index (number followed by h or d)
+    index_management_retention_time: "90d"
+    # Number of replicas for older sessions indices
+    index_management_older_session_replicas: "0"
+    # Number of weeks of history to retain
+    index_management_history_retention_weeks: "13"
+    # Number of segments to optimize sessions for
+    index_management_segments: "1"
+    # Whether or not Arkime should use a hot/warm design (storing non-session data in a warm index)
+    index_management_hot_warm_enabled: "false"
+  production:
+    free_space_g: "10%"
+    rotate_index: hourly
+    index_management_enabled: "true"
+    index_management_optimization_period: "3h"
+    index_management_retention_time: "4h"
+    index_management_older_session_replicas: "0"
+    index_management_history_retention_weeks: "1"
+    index_management_segments: "1"
+    index_management_hot_warm_enabled: "true"
 
 arkime_live:
   enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -267,17 +267,11 @@ zeek_live:
     worker_lb_procs: "1"
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "67108864"
-    zeek_pin_cpus_logger: ""
-    zeek_pin_cpus_manager: ""
-    zeek_pin_cpus_proxy: ""
   production:
     zeek_lb_procs: "24"
     worker_lb_procs: "24"
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "134217728"
-    zeek_pin_cpus_logger: ""
-    zeek_pin_cpus_manager: ""
-    zeek_pin_cpus_proxy: ""
 
 
 # Only affects the zeek offline deployment

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -466,3 +466,9 @@ process_env:
 # Only set to true if you intend on mounting these specific folders yourself using a kustomize overlay.
 rule_mount_override:
   enabled: false
+
+zeek_chart_overrides:
+  serviceAccountName: ""
+  sideCars: []
+  volumes: []
+  volumeMounts: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -104,7 +104,8 @@ siem_env:
     # Default time field used by for sessions in Arkime viewer
     arkime_network_index_time_field: "firstPacket"
   production:
-    malcolm_network_index_pattern: "malcolm_suricata_zeek-*"
+    # malcolm_network_index_pattern: "malcolm_suricata_zeek-*"
+    malcolm_network_index_pattern: "arkime_sessions3-*"
     malcolm_network_index_time_field: "firstPacket"
     malcolm_network_index_suffix: "%{%y%m%dh%H}"
     malcolm_other_index_pattern: "malcolm_beats_*"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -22,7 +22,7 @@ image:
   pcap_monitor_tag: ""
   arkime_tag: ""
   api_tag: ""
-  zeek_container_override: "ghcr.io/naps-dev/containers/zeek:malcolm-dev-24.03.0"
+  zeek_container_override: ""
   suricata_tag: ""
   dashboards_helper_tag: ""
   file_monitor_tag: ""
@@ -97,8 +97,9 @@ siem_env:
   malcolm_network_index_pattern: "arkime_sessions3-*"
   # Default time field to use for network traffic logs in Logstash and Dashboards
   malcolm_network_index_time_field: "firstPacket"
-  # Suffix used to create index to which network traffic logs are written (supports Ruby strftime strings in %{})
-  # e.g., hourly: %{%y%m%dh%H}, daily: %{%y%m%d}, weekly: %{%yw%U}, monthly: %{%ym%m}
+  # Suffix used to create index to which network traffic logs are written
+  #   (supports Ruby strftime strings in %{}; e.g.,
+  #    hourly: %{%y%m%dh%H}, twice daily: %{%P%y%m%d}, daily: %{%y%m%d}, weekly: %{%yw%U}, monthly: %{%ym%m})
   malcolm_network_index_suffix: "%{%y%m%d}"
   # Index pattern for other logs written via Logstash (e.g., nginx, beats, fluent-bit, etc.)
   malcolm_other_index_pattern: "malcolm_beats_*"
@@ -130,8 +131,11 @@ netbox:
   enabled: true
   # Set this this value to your reverse proxy url or leave it blank
   csrf_trusted_origins: https://malcolm.vp.bigbang.dev
-  netbox_default_site: Cyberville
+  netbox_default_site: Cyberville  
   netbox_auto_populate: false
+  netbox_cache_size: "1000"
+  netbox_cache_ttl: "30"
+
   database:
    host: netbox-postgres
    name: netbox
@@ -239,6 +243,8 @@ suricata_live:
     ftp_memcap: "64mb"
     stream_reassembly_memcap: "256mb"
     flow_memcap: "128mb"
+    eve_threaded: "true"
+    eve_rotate_interval: "1h"
     # Used if is production is set to true
   production:
     af_packet_iface_threads: 32
@@ -252,6 +258,8 @@ suricata_live:
     ftp_memcap: "4gb"
     stream_reassembly_memcap: "16gb"
     flow_memcap: "16gb"
+    eve_threaded: "true"
+    eve_rotate_interval: "1h"
 
 dashboards_helper_env:
   opensearch_index_size_prune_limit: 0
@@ -297,13 +305,6 @@ zeek_offline:
   production:
     zeek_auto_analyze_pcap_threads: 3
 
-upload_common_env:
-  # The age (in minutes) at which already-processed log files containing network traffic metadata should
-  #   be pruned from the filesystem
-  log_cleanup_minutes: 360
-  # The age (in minutes) at which the compressed archives containing already-processed log files should
-  #   be pruned from the filesystem
-  zip_cleanup_minutes: 720
 
 # Affects all zeek deployment live and offline
 zeek_env:
@@ -336,6 +337,7 @@ zeek_env:
 
 # Variables apply to both offline and live version of arkime
 arkime_env:
+  arkime_debug_level: "0"
   development:
     free_space_g: "10%"
     rotate_index: daily
@@ -433,8 +435,13 @@ filebeat:
   filebeat_close_inactive_live: 90m
   filebeat_ignore_older: 120m
   filebeat_scan_frequency: 10s
+  # The age (in minutes) at which already-processed log files containing network traffic metadata should
+  #   be pruned from the filesystem
+  log_cleanup_minutes: "60"
+  # The age (in minutes) at which the compressed archives containing already-processed log files should
+  #   be pruned from the filesystem
   zip_cleanup_minutes: "90"
-  log_cleanup_minutes: "90"
+
 
 # Default affinity ensures that the filebeat Daemonset is applied with anything that also has suricata or zeek live capture running on it.
   nodeAffinity:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -104,8 +104,7 @@ siem_env:
     # Default time field used by for sessions in Arkime viewer
     arkime_network_index_time_field: "firstPacket"
   production:
-    # malcolm_network_index_pattern: "malcolm_suricata_zeek-*"
-    malcolm_network_index_pattern: "arkime_sessions3-*"
+    malcolm_network_index_pattern: "malcolm_suricata_zeek-*"
     malcolm_network_index_time_field: "firstPacket"
     malcolm_network_index_suffix: "%{%y%m%dh%H}"
     malcolm_other_index_pattern: "malcolm_beats_*"
@@ -245,7 +244,7 @@ suricata_live:
     max_pending_packets: 8192
 
 dashboards_helper_env:
-  opensearch_index_size_prune_limit: 80%
+  opensearch_index_size_prune_limit: 0
   opensearch_index_size_prune_name_sort: false
 
 suricata_offline:
@@ -346,11 +345,11 @@ arkime_env:
   production:
     free_space_g: "10%"
     rotate_index: hourly
-    index_management_enabled: "true"
-    index_management_optimization_period: "3h"
-    index_management_retention_time: "4h"
+    index_management_enabled: "false"
+    index_management_optimization_period: "30d"
+    index_management_retention_time: "90d"
     index_management_older_session_replicas: "0"
-    index_management_history_retention_weeks: "1"
+    index_management_history_retention_weeks: "13"
     index_management_segments: "1"
     index_management_hot_warm_enabled: "false"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -104,7 +104,7 @@ siem_env:
     # Default time field used by for sessions in Arkime viewer
     arkime_network_index_time_field: "firstPacket"
   production:
-    malcolm_network_index_pattern: "arkime_sessions3-*"
+    malcolm_network_index_pattern: "malcolm_suricata_zeek-*"
     malcolm_network_index_time_field: "firstPacket"
     malcolm_network_index_suffix: "%{%y%m%dh%H}"
     malcolm_other_index_pattern: "malcolm_beats_*"
@@ -237,11 +237,11 @@ suricata_live:
     max_pending_packets: 1024
     # Used if is production is set to true
   production:
-    af_packet_iface_threads: 16
+    af_packet_iface_threads: 32
     # Default is calculated threads * max-pending-packets (Default of max-pending-packets is 1024)
     # This calculation was made with the assumtion that max-pending-packets is set to 1024
-    af_packet_ring_size: 65536
-    max_pending_packets: 4096
+    af_packet_ring_size: 131072
+    max_pending_packets: 8192
 
 dashboards_helper_env:
   opensearch_index_size_prune_limit: 80%
@@ -351,7 +351,7 @@ arkime_env:
     index_management_older_session_replicas: "0"
     index_management_history_retention_weeks: "1"
     index_management_segments: "1"
-    index_management_hot_warm_enabled: "true"
+    index_management_hot_warm_enabled: "false"
 
 arkime_live:
   enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -472,3 +472,13 @@ zeek_chart_overrides:
   sideCars: []
   volumes: []
   volumeMounts: []
+  live_volumes: []
+  live_volumeMounts: []
+
+suricata_chart_overrides:
+  serviceAccountName: ""
+  sideCars: []
+  volumes: []
+  volumeMounts: []
+  live_volumes: []
+  live_volumeMounts: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -131,7 +131,7 @@ netbox:
   enabled: true
   # Set this this value to your reverse proxy url or leave it blank
   csrf_trusted_origins: https://malcolm.vp.bigbang.dev
-  netbox_default_site: Cyberville  
+  netbox_default_site: Cyberville
   netbox_auto_populate: false
   netbox_cache_size: "1000"
   netbox_cache_ttl: "30"
@@ -139,9 +139,10 @@ netbox:
   database:
    host: netbox-postgres
    name: netbox
+   password: "ChangeMe!"
    # Set true if using custom database for netbox
    is_custom: false
-   # Create extra secrets for database, empty attributes will be set to randomly general postgres password.
+   # Create extra secrets for custom database, empty attributes will be set to password key.
    # The password will be same for all empty attributes.
    extra_secrets: [{}]
     # Example

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -355,8 +355,8 @@ arkime_env:
     # Whether or not Arkime should use a hot/warm design (storing non-session data in a warm index)
     index_management_hot_warm_enabled: "false"
   production:
-    free_space_g: "10%"
-    rotate_index: daily
+    free_space_g: "20%"
+    rotate_index: hourly
     index_management_enabled: "false"
     index_management_optimization_period: "30d"
     index_management_retention_time: "90d"
@@ -433,6 +433,8 @@ filebeat:
   filebeat_close_inactive_live: 90m
   filebeat_ignore_older: 120m
   filebeat_scan_frequency: 10s
+  zip_cleanup_minutes: "90"
+  log_cleanup_minutes: "90"
 
 # Default affinity ensures that the filebeat Daemonset is applied with anything that also has suricata or zeek live capture running on it.
   nodeAffinity:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -86,32 +86,30 @@ external_elasticsearch:
 siem_env:
   # OpenSearch index patterns and timestamp fields
   # Index pattern for network traffic logs written via Logstash (e.g., Zeek logs, Suricata alerts)
-  development:
-    malcolm_network_index_pattern: "arkime_sessions3-*"
-    # Default time field to use for network traffic logs in Logstash and Dashboards
-    malcolm_network_index_time_field: "firstPacket"
-    # Suffix used to create index to which network traffic logs are written (supports Ruby strftime strings in %{})
-    # e.g., hourly: %{%y%m%dh%H}, daily: %{%y%m%d}, weekly: %{%yw%U}, monthly: %{%ym%m}
-    malcolm_network_index_suffix: "%{%y%m%d}"
-    # Index pattern for other logs written via Logstash (e.g., nginx, beats, fluent-bit, etc.)
-    malcolm_other_index_pattern: "malcolm_beats_*"
-    # Default time field to use for other logs in Logstash and Dashboards
-    malcolm_other_index_time_field: "@timestamp"
-    # Suffix used to create index to which other logs are written (supports Ruby strftime strings in %{})
-    malcolm_other_index_suffix: "%{%y%m%d}"
-    # Index pattern used specifically by Arkime (will probably match MALCOLM_NETWORK_INDEX_PATTERN, should probably be arkime_sessions3-*)
-    arkime_network_index_pattern: "arkime_sessions3-*"
-    # Default time field used by for sessions in Arkime viewer
-    arkime_network_index_time_field: "firstPacket"
-  production:
-    malcolm_network_index_pattern: "malcolm_suricata_zeek-*"
-    malcolm_network_index_time_field: "firstPacket"
-    malcolm_network_index_suffix: "%{%y%m%d}"
-    malcolm_other_index_pattern: "malcolm_beats_*"
-    malcolm_other_index_time_field: "@timestamp"
-    malcolm_other_index_suffix: "%{%y%m%d}"
-    arkime_network_index_pattern: "arkime_sessions3-*"
-    arkime_network_index_time_field: "firstPacket"
+  logstash_override:
+    # When enabled the elasticsearch / opensarch logstash output plugin is modified to point to an ilm rollover alias
+    # ILM policy and rollover_alias will need to be defined outside of this deployment for this to work as expected.
+    enabled: false
+    ilm_policy: nta
+    # Must match arkime_network_index_pattern
+    rollover_alias: malcolm_suricata_zeek
+
+  malcolm_network_index_pattern: "arkime_sessions3-*"
+  # Default time field to use for network traffic logs in Logstash and Dashboards
+  malcolm_network_index_time_field: "firstPacket"
+  # Suffix used to create index to which network traffic logs are written (supports Ruby strftime strings in %{})
+  # e.g., hourly: %{%y%m%dh%H}, daily: %{%y%m%d}, weekly: %{%yw%U}, monthly: %{%ym%m}
+  malcolm_network_index_suffix: "%{%y%m%d}"
+  # Index pattern for other logs written via Logstash (e.g., nginx, beats, fluent-bit, etc.)
+  malcolm_other_index_pattern: "malcolm_beats_*"
+  # Default time field to use for other logs in Logstash and Dashboards
+  malcolm_other_index_time_field: "@timestamp"
+  # Suffix used to create index to which other logs are written (supports Ruby strftime strings in %{})
+  malcolm_other_index_suffix: "%{%y%m%d}"
+  # Index pattern used specifically by Arkime (will probably match MALCOLM_NETWORK_INDEX_PATTERN, should probably be arkime_sessions3-*)
+  arkime_network_index_pattern: "arkime_sessions3-*"
+  # Default time field used by for sessions in Arkime viewer
+  arkime_network_index_time_field: "firstPacket"
 
 
 logstash:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -269,7 +269,6 @@ zeek_live:
     zeek_af_packet_buffer_size: "67108864"
     zeek_pin_cpus_logger: ""
     zeek_pin_cpus_manager: ""
-    zeek_pin_cpus_manager: ""
     zeek_pin_cpus_proxy: ""
   production:
     zeek_lb_procs: "24"
@@ -277,7 +276,6 @@ zeek_live:
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "134217728"
     zeek_pin_cpus_logger: ""
-    zeek_pin_cpus_manager: ""
     zeek_pin_cpus_manager: ""
     zeek_pin_cpus_proxy: ""
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -371,7 +371,7 @@ arkime_live:
   enabled: true
   pcap_hostpath: "/zpool/nta-pcap"
   development:
-    arkime_compression_type: zstd
+    arkime_compression_type: none
     arkime_compression_level: "0"
     arkime_db_bulk_size: "4000000"
     arkime_max_packets_in_queue: "300000"
@@ -380,7 +380,7 @@ arkime_live:
     arkime_tpacketv3_num_threads: "2"
     arkime_tpacketv3_block_size: "8388608"
   production:
-    arkime_compression_type: zstd
+    arkime_compression_type: none
     arkime_compression_level: "3"
     arkime_db_bulk_size: "4000000"
     arkime_max_packets_in_queue: "300000"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -106,7 +106,7 @@ siem_env:
   production:
     malcolm_network_index_pattern: "malcolm_suricata_zeek-*"
     malcolm_network_index_time_field: "firstPacket"
-    malcolm_network_index_suffix: "%{%y%m%dh%H}"
+    malcolm_network_index_suffix: "%{%y%m%d}"
     malcolm_other_index_pattern: "malcolm_beats_*"
     malcolm_other_index_time_field: "@timestamp"
     malcolm_other_index_suffix: "%{%y%m%d}"
@@ -344,7 +344,7 @@ arkime_env:
     index_management_hot_warm_enabled: "false"
   production:
     free_space_g: "10%"
-    rotate_index: hourly
+    rotate_index: daily
     index_management_enabled: "false"
     index_management_optimization_period: "30d"
     index_management_retention_time: "90d"

--- a/vagrant_dependencies/Corefile.yaml
+++ b/vagrant_dependencies/Corefile.yaml
@@ -8,7 +8,6 @@ metadata:
     meta.helm.sh/release-namespace: kube-system
   labels:
     app.kubernetes.io/instance: rke2-coredns
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: rke2-coredns
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
1. Upgraded Malcolm from 24.03.0 to 24.03.1
2. Turned off PCAP compression so raw pcap is viewable by Arkime viewer
3. Changed malcolm_template.json based on logstash override variable in values.yaml file.
4. Changed 99_opensearch_output.conf based on logstash override variable in values.yaml file.
5. Added LOG_CLEANUP_MINUTES and ZIP_CLEANUP_MINUTES to fix logs not rotating properly.
6. Scaled the logstash deploymen based on number of nodes / 2 with a minimum of 1.
7. Added zeek cpu pins
8. Added stream, host, defrag, ftp, stream reassembly and flow memcaps to suricata
9. Made arkime rotate and free_space_g production variables.
10. Updated lb_procs 24 for zeek.
11. Updated suricata af_packet_iface_threads to 32 workers.
12. Changed zeek extrac_mode to interesting.
13. Bumped arkime packet threads from 8 to 16
14. Arkime drops / filters out tls traffic and pcap is also compressed compressing PCAP zstd to save disk
15. Changed where zeek and suricata are dropping their logs to /zpool/nta-logs
