### PR TITLE
Move the 99-ingress spec rules to values.yaml for easier editing

### DIFF
--- a/chart/templates/99-ingress-nginx.yml
+++ b/chart/templates/99-ingress-nginx.yml
@@ -19,14 +19,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 spec:
-  rules:
-  - http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: nginx-proxy
-            port:
-              number: 443
+{{- toYaml .Values.ingress.specRules | nindent 2 }}
 {{- end }}
+

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -227,8 +227,21 @@ storage:
       className: local-path
 
 ingress:
-  # Enable this if deploying in RKE2 environment with the default nginx ingress controller
+  # Enable this to use the default nginx ingress controller
   enabled: true
+  specRules:
+    rules:
+    - http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: nginx-proxy
+              port:
+                number: 443
+      # uncomment this line if you want to specify an ingress hostname with the path above
+      # host: "malcolm.malcolmhost.network.local"
 
 istio:
   # Enable this if deploying in Kuberenetes environment leveraging istio service mesh


### PR DESCRIPTION
Moved the 99-ingress spec path and host header settings into values.yaml so deployment options are configured in one place.