### PR TITLE
put a conditional around inclusion of 'keycloak-env' 98-nginx-proxy.yml

### DIFF
--- a/chart/templates/98-nginx-proxy.yml
+++ b/chart/templates/98-nginx-proxy.yml
@@ -91,8 +91,10 @@ spec:
               name: opensearch-env
           - configMapRef:
               name: dashboards-env
+          {{- if or (eq .Values.auth.mode "keycloak") (eq .Values.auth.mode "keycloak_remote") }}
           - secretRef:
               name: keycloak-env
+          {{- end }}
           - configMapRef:
               name: auth-common-env
           - configMapRef:


### PR DESCRIPTION
Don't include 'keycloak-env' configMap in 98-nginx-proxy.yml unless auth.mode is 'keycloak' or 'keycloak_remote' (since those are the only conditions in which that configMap exists). This matches what's done in the malcolm secrets yaml.