### PR TITLE
fix issues with arkime-live entrypoint

### DIFF
--- a/chart/templates/arkime_configmaps.yml
+++ b/chart/templates/arkime_configmaps.yml
@@ -169,10 +169,12 @@ metadata:
 data:
   command_override.sh: |
     #!/bin/bash
-    sed -i 's/NODE_NAME=${PCAP_NODE_NAME:-"malcolm"}-live/NODE_NAME=${PCAP_NODE_NAME}/' /opt/live_capture.sh
-    sed -i 's/NODE_HOST=${ARKIME_LIVE_NODE_HOST:-""}/NODE_HOST=${NODE_NAME}/' /opt/live_capture.sh
-    /usr/bin/tini -- /usr/local/bin/docker-uid-gid-setup.sh /usr/local/bin/service_check_passthrough.sh -s arkime /usr/local/bin/docker_entrypoint.sh
-    /usr/bin/supervisord -c /etc/supervisord.conf -n
+    sed -i 's/NODE_NAME=${PCAP_NODE_NAME:-"malcolm"}-live/NODE_NAME=${PCAP_NODE_NAME}/' /usr/local/bin/live_capture.sh
+    sed -i 's/NODE_HOST=${ARKIME_LIVE_NODE_HOST:-""}/NODE_HOST=${NODE_NAME}/' /usr/local/bin/live_capture.sh
+    /usr/bin/tini -s -- /usr/local/bin/docker-uid-gid-setup.sh \
+      /usr/local/bin/service_check_passthrough.sh -s arkime \
+      /usr/local/bin/docker_entrypoint.sh \
+      /usr/bin/supervisord -c /etc/supervisord.conf -n
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/chart/templates/arkime_configmaps.yml
+++ b/chart/templates/arkime_configmaps.yml
@@ -171,7 +171,7 @@ data:
     #!/bin/bash
     sed -i 's/NODE_NAME=${PCAP_NODE_NAME:-"malcolm"}-live/NODE_NAME=${PCAP_NODE_NAME}/' /opt/live_capture.sh
     sed -i 's/NODE_HOST=${ARKIME_LIVE_NODE_HOST:-""}/NODE_HOST=${NODE_NAME}/' /opt/live_capture.sh
-    /usr/bin/tini -- /usr/local/bin/docker-uid-gid-setup.sh /usr/local/bin/service_check_passthrough.sh -s arkime /opt/docker_entrypoint.sh
+    /usr/bin/tini -- /usr/local/bin/docker-uid-gid-setup.sh /usr/local/bin/service_check_passthrough.sh -s arkime /usr/local/bin/docker_entrypoint.sh
     /usr/bin/supervisord -c /etc/supervisord.conf -n
 ---
 apiVersion: v1


### PR DESCRIPTION
A [commit in a recent version](https://github.com/cisagov/Malcolm/blame/ca32612c76b977eb3749bbeda2b16f32c2b3e872/Dockerfiles/arkime.Dockerfile#L214) of Malcolm moved the file `/opt/docker_entrypoint.sh` to `/usr/local/bin/docker_entrypoint.sh` and changed the path in the Dockerfile. However, the Helm chart's `command_override.sh` it uses instead for arkime-live did not get updated to reflect that.