### PR TITLE
add container ports for file-monitor service to be tested by the API service

### DIFF
--- a/chart/templates/12-file-monitor.yml
+++ b/chart/templates/12-file-monitor.yml
@@ -20,6 +20,12 @@ spec:
     - port: 3310
       protocol: TCP
       name: clamav
+    - port: 5987
+      protocol: TCP
+      name: filetopic
+    - port: 5988
+      protocol: TCP
+      name: loggertopic
     - port: 8440
       protocol: TCP
       name: http
@@ -54,6 +60,12 @@ spec:
         ports:
           - name: clamav
             containerPort: 3310
+            protocol: TCP
+          - name: filetopic
+            containerPort: 5987
+            protocol: TCP
+          - name: loggertopic
+            containerPort: 5988
             protocol: TCP
           - name: http
             protocol: TCP


### PR DESCRIPTION
The [/ready API](https://idaholab.github.io/Malcolm/docs/api-ready.html) checks a couple of ports of the `file-monitor` container to make sure they're accepting connections. However, without the ports specified in the chart for that service, that connection fails and the ready api says "false" even though they are actually open.

This adds those container ports to the file-monitor manifest.