### PR TITLE
Improvements and performance tweaks for Vagrant file / development mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 *.orig
 .vagrant/
+.envrc

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -213,6 +213,10 @@ Vagrant.configure("2") do |config|
 
   if script_choice == 'use_istio'
     config.vm.provision "shell", inline: <<-SHELL
+      echo "Wait for cluster to become ready..." >&2
+      until kubectl wait --for=condition=Ready nodes --all --timeout=19 >/dev/null 2>&1; do
+        sleep 1
+      done
       # Setup metallb
       helm repo add metallb https://metallb.github.io/metallb
       helm repo update metallb

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -214,7 +214,7 @@ Vagrant.configure("2") do |config|
   if script_choice == 'use_istio'
     config.vm.provision "shell", inline: <<-SHELL
       echo "Wait for cluster to become ready..." >&2
-      until kubectl wait --for=condition=Ready nodes --all --timeout=19 >/dev/null 2>&1; do
+      until kubectl wait --for=condition=Ready nodes --all --timeout=19s >/dev/null 2>&1; do
         sleep 1
       done
       # Setup metallb

--- a/chart/templates/14-logstash.yml
+++ b/chart/templates/14-logstash.yml
@@ -16,16 +16,14 @@ data:
   LOGSTASH_SEVERITY_SCORING: "true"
   {{- if .Values.is_production }}
     {{- with .Values.logstash.production }}
-  LS_JAVA_OPTS: -server {{ .java_memory }}:-HeapDumpOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom
-    -Dlog4j.formatMsgNoLookups=true
+  LS_JAVA_OPTS: -server {{ .java_memory }} -XX:-HeapDumpOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dlog4j.formatMsgNoLookups=true -Dlogstash.pipelinebus.implementation=v1
   pipeline.batch.delay: "{{ .batch_delay }}"
   pipeline.batch.size: "{{ .batch_size }}"
   pipeline.workers: "{{ .workers }}"
     {{- end }}
   {{- else }}
     {{- with .Values.logstash.development }}
-  LS_JAVA_OPTS: -server {{ .java_memory }}:-HeapDumpOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom
-    -Dlog4j.formatMsgNoLookups=true
+  LS_JAVA_OPTS: -server {{ .java_memory }} -XX:-HeapDumpOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dlog4j.formatMsgNoLookups=true -Dlogstash.pipelinebus.implementation=v1
   # Parameters for tuning Logstash pipelines (see
   #   https://www.elastic.co/guide/en/logstash/current/logstash-settings-file.html)
   pipeline.batch.delay: "{{ .batch_delay }}"

--- a/chart/templates/23-arkime-live.yml
+++ b/chart/templates/23-arkime-live.yml
@@ -86,7 +86,7 @@ spec:
           failureThreshold: 10
         volumeMounts:
           - mountPath: /opt/arkime/etc/config.orig.ini
-            name: arkime-config-default
+            name: arkime-live-config-default
             subPath: config.ini
           - name: arkime-live-shell-override-volume
             mountPath: /opt/command_override.sh
@@ -125,7 +125,7 @@ spec:
           - name: arkime-live-pcap-volume
             mountPath: "/data/pcap"
       volumes:
-        - name: arkime-config-default
+        - name: arkime-live-config-default
           configMap:
             name: arkime-config
         - name: arkime-live-var-local-catrust-volume

--- a/chart/templates/99-ingress-nginx.yml
+++ b/chart/templates/99-ingress-nginx.yml
@@ -5,7 +5,6 @@ kind: Ingress
 metadata:
   name: nginx-ingress
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/backend-protocol: "http"
     nginx.ingress.kubernetes.io/preserve-trailing-slash: "false"
     nginx.ingress.kubernetes.io/ssl-passthrough: "false"
@@ -19,6 +18,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 spec:
+  ingressClassName: "nginx"
 {{- toYaml .Values.ingress.specRules | nindent 2 }}
 {{- end }}
 

--- a/chart/templates/malcolm_configmaps.yaml
+++ b/chart/templates/malcolm_configmaps.yaml
@@ -139,13 +139,11 @@ data:
   OPENSEARCH_CREDS_CONFIG_FILE: /var/local/curlrc/.opensearch.primary.curlrc
 {{- if .Values.is_production }}
   {{- with .Values.opensearch.production }}
-  OPENSEARCH_JAVA_OPTS: -server {{ .java_memory }}:-HeapDumpOnOutOfMemoryError
-    -Djava.security.egd=file:/dev/./urandom -Dlog4j.formatMsgNoLookups=true
+  OPENSEARCH_JAVA_OPTS: -server {{ .java_memory }} -XX:-HeapDumpOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dlog4j.formatMsgNoLookups=true
   {{- end }}
 {{- else }}
   {{- with .Values.opensearch.development }}
-  OPENSEARCH_JAVA_OPTS: -server {{ .java_memory }}:-HeapDumpOnOutOfMemoryError
-    -Djava.security.egd=file:/dev/./urandom -Dlog4j.formatMsgNoLookups=true
+  OPENSEARCH_JAVA_OPTS: -server {{ .java_memory }} -XX:-HeapDumpOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom -Dlog4j.formatMsgNoLookups=true
   {{- end }}
 {{- end }}
   OPENSEARCH_PRIMARY: "{{ include "malcolm.opensearchprimary" . }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -55,9 +55,9 @@ opensearch:
   url: http://opensearch:9200
   dashboards_url: http://dashboards:5601/dashboards
   development:
-    java_memory: -Xmx4g -Xms4g -Xss256k -XX
+    java_memory: -Xmx10g -Xms10g -Xss256k
   production:
-    java_memory: -Xmx32g -Xms32g -Xss256k -XX
+    java_memory: -Xmx32g -Xms32g -Xss256k
 
 external_elasticsearch:
   enabled: false
@@ -136,13 +136,13 @@ siem_env:
 logstash:
   # Note the number of logstash instances will be based on the number of nodes in your kubernetes cluster.
   development:
-    java_memory: -Xmx2500m -Xms2500m -Xss1536k -XX
+    java_memory: -Xmx2500m -Xms2500m -Xss2048k
     #See https://www.elastic.co/guide/en/logstash/current/tuning-logstash.html for details on these parameters.
-    workers: 3
+    workers: 2
     batch_delay: 50
     batch_size: 75
   production:
-    java_memory: -Xmx16g -Xms16g -Xss1536k -XX
+    java_memory: -Xmx16g -Xms16g -Xss2048k
     workers: 18
     batch_delay: 50
     batch_size: 75

--- a/scripts/bash_convenience
+++ b/scripts/bash_convenience
@@ -1,0 +1,37 @@
+
+alias k="kubectl"
+
+export KUBESPACE=malcolm
+
+function kpods () {
+    local NAMESPACE="${1:-$KUBESPACE}"
+    kubectl --kubeconfig "${KUBECONFIG}" get pods --no-headers --namespace "${NAMESPACE}"
+}
+
+function kshell () {
+    local SERVICE="${1:-nginx-proxy}"
+    local NAMESPACE="${2:-$KUBESPACE}"
+    local SHELL="${3:-/bin/bash}"
+    local POD="$(kubectl --kubeconfig "${KUBECONFIG}" get pods --no-headers --namespace "${NAMESPACE}" | grep "^${SERVICE}" | awk '{print $1}' | sort | head -n 1)"
+    if [[ -n "${POD}" ]]; then
+        kubectl --kubeconfig "${KUBECONFIG}" exec --stdin --tty --namespace "${NAMESPACE}" "${POD}" -- "${SHELL}"
+    else
+        echo "Unable to identify pod for ${SERVICE} in ${NAMESPACE}" >&2
+    fi
+}
+
+function klogs () {
+    local SERVICE="${1:-nginx-proxy}"
+    local NAMESPACE="${2:-$KUBESPACE}"
+    local SHELL="${3:-/bin/bash}"
+    local POD="$(kubectl --kubeconfig "${KUBECONFIG}" get pods --no-headers --namespace "${NAMESPACE}" | grep "^${SERVICE}" | awk '{print $1}' | sort | head -n 1)"
+    if [[ -n "${POD}" ]]; then
+        if command -v stern >/dev/null 2>&1; then
+            stern --kubeconfig "${KUBECONFIG}" --namespace "${NAMESPACE}" --container '.*' --container-state all "${POD}"
+        else
+            kubectl --kubeconfig "${KUBECONFIG}" logs --namespace "${NAMESPACE}" --follow=true --all-containers "${POD}"
+        fi
+    else
+        echo "Unable to identify pod for ${SERVICE} in ${NAMESPACE}" >&2
+    fi
+}


### PR DESCRIPTION
Includes the following changes:

* Vagrantfile / repo environment changes
    * added some new features and allow them to be configured via environment variables at runtime
        * `VAGRANT_DEFAULT_PROVIDER` - Vagrant provider (default is environment-specific)
            * Vagrantfile now has support for `virtualbox`, `libvirt`, and `vmware` providers
        * `VAGRANT_SETUP_CHOICE` - not new, either `use_istio` or blank
        * `VAGRANT_BOX` - base Vagrant box (default `bento/debian-12`, previously `ubuntu/jammy64`; Canonical no longer publishes official Vagrant boxes for Ubuntu, and Kernel performance improvements involving containers prompted the move to a more recent distribution)
        * `VAGRANT_CPUS` - number of CPUs for the VM (default `8`)
        * `VAGRANT_MEMORY` - memory, in megabytes, for the VM (default `24576`)
        * `VAGRANT_DISK_SIZE` - maximum size for extra disk (default `400GB`)
            * Previously the `vagrant-disksize` plugin resized the primary disk. For performance and compatibility with other Vagrant boxes, we now create a separate disk, format it, and set it aside for the use of Rancher and the local path provisioner storage type.
        * `VAGRANT_NAME` - VM name (default `Malcolm-Helm`)
        * `VAGRANT_GUI` - Whether or not to show GUI, `true` or `false` (default `true`, VirtualBox only)
        * `VAGRANT_SSD` - Whether or not to mark disk as SSDs (default `on`, VirtualBox and VMware only)
    * performance tweaks
        * added/modified sysctl settings
        * added kernel parameter arguments for grub
        * set ulimits in `/etc/security/limits.d/limits.conf` 
    * adjusted a few timings of sleeps on initial provisioning
    * updated versions of istio (1.25.1) and rke2 (v1.30.3+rke2r1)
    * added `.envrc` to `.gitignore` for those of us using `direnv`
    * in addition to `k=kubectl` alias, added some convenience functions to `.bashrc`
        * `kpods` - list the pods in the Malcolm namespace
        * `kshell <pod name>` - get a shell into a pod
        * `klogs <pod name>` - tail the logs for a pod
* Helm Chart changes
    * updated and fixed formatting of the `LS_JAVA_OPTS` and `OPENSEARCH_JAVA_OPTS` variables
    * renamed a volume mount in the `arkime-live` container to be `arkime-live-config-default` (from `arkime-config-default`) to be consistent with the naming convention of the other mounts there
    * default opensearch memory for `development` profile to `10g` (from `4g`)
    * set stack size for Logstash java memory to `2048k` (from `1536k`)

