### PR TITLE
VDP-1006: Fix netbox crashes with FIPS enabled

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/malcolm_configmaps.yaml
+++ b/chart/templates/malcolm_configmaps.yaml
@@ -112,6 +112,7 @@ data:
   SKIP_SUPERUSER: "false"
   SUPERUSER_EMAIL: admin@example.com
   WEBHOOKS_ENABLED: "true"
+  OPENSSL_FORCE_FIPS_MODE: "0"
 kind: ConfigMap
 metadata:
   name: netbox-env


### PR DESCRIPTION
Hard-code an environment variable to force disablement of FIPS.

I tested this on both my vkit (no fips) and kit 4 (fips).