### PR TITLE
VDP-1081: Expose setting for ZEEK_LB_PROCS_WORKER_DEFAULT

### DIFF
--- a/chart/templates/21-zeek-live.yml
+++ b/chart/templates/21-zeek-live.yml
@@ -14,6 +14,7 @@ data:
   ZEEK_DISABLE_STATS: "{{ .Values.zeek_live.zeek_disable_stats }}"
   {{- if .Values.is_production }}
     {{- with .Values.zeek_live.production }}
+  ZEEK_LB_PROCS_WORKER_DEFAULT: "{{ .zeek_lb_procs_worker_default }}"
   ZEEK_LB_PROCS: "{{ .zeek_lb_procs }}"
   WORKER_LB_PROCS: "{{ .worker_lb_procs }}"
   ZEEK_LB_METHOD: "{{ .zeek_lb_method }}"
@@ -22,6 +23,7 @@ data:
     {{- end }}
   {{- else }}
     {{- with .Values.zeek_live.development }}
+  ZEEK_LB_PROCS_WORKER_DEFAULT: "{{ .zeek_lb_procs_worker_default }}"
   ZEEK_LB_PROCS: "{{ .zeek_lb_procs }}"
   WORKER_LB_PROCS: "{{ .worker_lb_procs }}"
   ZEEK_LB_METHOD: "{{ .zeek_lb_method }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -345,12 +345,14 @@ zeek_live:
     cnaps.io/zeek-capture: "true"
 
   development:
+    zeek_lb_procs_worker_default: ""
     zeek_lb_procs: "1"
     worker_lb_procs: "1"
     zeek_lb_method: "custom"
     zeek_af_packet_buffer_size: "67108864"
     zeek_pin_cpus_worker_1: ""
   production:
+    zeek_lb_procs_worker_default: "8"
     zeek_lb_procs: "32"
     worker_lb_procs: "32"
     zeek_lb_method: "custom"


### PR DESCRIPTION
* Allow specification of the number of zeek worker processes in order to handle higher data rates.

I have tested this change by deploying malcolm on hardware kit 4.