### PR TITLE
Escape grep slashes to survive Ruby interpolation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -276,7 +276,7 @@ Vagrant.configure("2") do |config|
   else
     config.vm.provision "shell", inline: <<-SHELL
       echo "Waiting for rke2-ingress-nginx-controller-admission..." >&2
-      until kubectl get endpoints --namespace kube-system 2>/dev/null | grep -Pq "rke2-ingress-nginx-controller-admission\s+.+:\d+"; do
+      until kubectl get endpoints --namespace kube-system 2>/dev/null | grep -Pq "rke2-ingress-nginx-controller-admission\\s+.+:\\d+"; do
         sleep 20
       done
       echo "rke2-ingress-nginx-controller-admission is present" >&2


### PR DESCRIPTION
I looks like the Ruby interpreter is stripping slashes from the Vagrantfile grep command that checks if ingress-nginx-conroller-admission endpoint is up. Adding extra escape back-slashes results in the correct command sent through Ruby to Bash.