### PR TITLE
Remove hard-coded namespace

### DIFF
--- a/chart/templates/16-redis-cache.yml
+++ b/chart/templates/16-redis-cache.yml
@@ -5,7 +5,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis-cache
-  namespace: malcolm
 spec:
   ports:
     - port: 6379

--- a/chart/templates/23-arkime-live.yml
+++ b/chart/templates/23-arkime-live.yml
@@ -6,7 +6,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: arkime-live-daemonset
-  namespace: malcolm
 spec:
   selector:
     matchLabels:

--- a/chart/templates/25-keycloak.yml
+++ b/chart/templates/25-keycloak.yml
@@ -5,7 +5,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: keycloak
-  namespace: malcolm
 spec:
   ports:
     - port: 8080
@@ -18,7 +17,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: keycloak-deployment
-  namespace: malcolm
 spec:
   selector:
     matchLabels:

--- a/chart/templates/malcolm_secrets.yaml
+++ b/chart/templates/malcolm_secrets.yaml
@@ -89,7 +89,6 @@ data:
 kind: Secret
 metadata:
   name: opensearch-curlrc
-  namespace: malcolm
 type: Opaque
 
 ---

--- a/chart/templates/network_policies.yml
+++ b/chart/templates/network_policies.yml
@@ -71,7 +71,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-istio-ingress-egress
-  namespace: malcolm
 spec:
   # Select all the pods
   podSelector: {}
@@ -123,7 +122,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-all-to-ingress-proxy
-  namespace: malcolm
 spec:
   podSelector:
     matchLabels:

--- a/vagrant_dependencies/test-gateway.yml
+++ b/vagrant_dependencies/test-gateway.yml
@@ -20,7 +20,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: test-virtualservice
-  namespace: malcolm
 spec:
   hosts:
   - "malcolm.test.dev"


### PR DESCRIPTION
Several Malcom-Helm template files have the namespace hard-coded to 'malcolm'. This precludes the ability to deploy to any other namespace which can be a problem for shared development clusters where multiple developers rely on namespaces for deployment separation. Removing these hard-coded namespaces still allows for deploying to the 'malcolm' namespace with the '-n' option (helm install malcolm /vagrant/chart -n malcolm --create-namespace) but also supports arbitrary namespace deployments for shared environments.

Tested Helm Chart deployment on shared Kubernetes Cluster
Tested Vagrant deployment with debian/bookworm64 Vagrant box using both VirtualBox and Libvirt providers.