### PR TITLE
Rollover alias fix

### DIFF
--- a/chart/templates/09-dashboards-helper.yml
+++ b/chart/templates/09-dashboards-helper.yml
@@ -104,6 +104,9 @@ spec:
           - mountPath: /opt/templates/malcolm_template_suricata.json
             name: malcolm-template-override
             subPath: malcolm_template_suricata.json
+          - mountPath: /opt/templates/malcolm_beats_template.json
+            name: malcolm-template-override
+            subPath: malcolm_beats_template.json
 {{- end }}
       volumes:
         - name: dashboards-helper-var-local-catrust-volume

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -193,7 +193,8 @@ data:
         "lifecycle.rollover_alias": "{{ .rollover_alias }}",
         "mapping.total_fields.limit" : "6000",
         "mapping.nested_fields.limit" : "250",
-        "max_docvalue_fields_search" : "200"
+        "max_docvalue_fields_search" : "200",
+        "default_pipeline": "{{ .default_beats_pipeline }}"
       }
     },
     "mappings": {

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -157,6 +157,57 @@ data:
 {{- end }}
 {{- end }}
 
+{{- define "malcolm.beatstemplate" }}
+{
+  "index_patterns" : ["{{ .index_patterns }}"],
+  "composed_of": [
+    "ecs_base",
+    "ecs_ecs",
+    "ecs_event",
+    "ecs_agent",
+    "ecs_client",
+    "ecs_destination",
+    "ecs_error",
+    "ecs_file",
+    "ecs_host",
+    "ecs_http",
+    "ecs_log",
+    "ecs_network",
+    "ecs_process",
+    "ecs_related",
+    "ecs_server",
+    "ecs_source",
+    "ecs_threat",
+    "ecs_url",
+    "ecs_user",
+    "ecs_user_agent",
+    "custom_miscbeat",
+    "custom_suricata_stats",
+    "custom_winlog",
+    "custom_zeek_diagnostic"
+  ],
+  "template" :{
+    "settings" : {
+      "index" : {
+        "lifecycle.name": "{{ .ilm_policy }}",
+        "lifecycle.rollover_alias": "{{ .rollover_alias }}",
+        "mapping.total_fields.limit" : "6000",
+        "mapping.nested_fields.limit" : "250",
+        "max_docvalue_fields_search" : "200"
+      }
+    },
+    "mappings": {
+      "properties": {
+        "timestamp": { "type": "date" },
+        "node": { "type": "keyword" },
+        "event.result": { "type": "keyword" },
+        "os.family": { "type": "keyword" },
+        "os.type": { "type": "keyword" }
+      }
+    }
+  }
+}
+{{- end }}
 
 {{- define "malcolm.ecstemplate" }}
 {

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -194,7 +194,7 @@ data:
         "mapping.total_fields.limit" : "6000",
         "mapping.nested_fields.limit" : "250",
         "max_docvalue_fields_search" : "200",
-        "default_pipeline": "{{ .default_beats_pipeline }}"
+        "default_pipeline": "{{ .default_pipeline }}"
       }
     },
     "mappings": {

--- a/chart/templates/logstash_override.yml
+++ b/chart/templates/logstash_override.yml
@@ -9,8 +9,10 @@ data:
           hosts => "${OPENSEARCH_URL:http://opensearch:9200}"
           ssl_certificate_verification => "false"
           manage_template => false
-          index => "%{[@metadata][malcolm_opensearch_index]}"
           document_id => "%{+YYMMdd}-%{[event][hash]}"
+          ilm_rollover_alias => "{{ .Values.siem_env.logstash_override.rollover_alias_beats }}"
+          ilm_pattern => "000001"
+          ilm_policy => "{{ .Values.siem_env.logstash_override.ilm_beats_policy }}"
         }
       } else if [event][provider] == "suricata" {
         elasticsearch {
@@ -48,6 +50,9 @@ data:
 
   malcolm_template_suricata.json: |
     {{- include "malcolm.ecstemplate" (dict "index_patterns" (printf "%s-*" .Values.siem_env.logstash_override.rollover_alias_suricata) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_suricata "ilm_policy" .Values.siem_env.logstash_override.ilm_policy "search_alias" .Values.siem_env.logstash_override.search_alias) | indent 4 }}
+
+  malcolm_beats_template.json: |
+    {{- include "malcolm.beatstemplate" (dict "index_patterns" (printf "%s-*" .Values.siem_env.logstash_override.rollover_alias_beats) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_beats "ilm_policy" .Values.siem_env.logstash_override.ilm_beats_policy) | indent 4 }}
 kind: ConfigMap
 metadata:
   name: malcolm-template-override

--- a/chart/templates/logstash_override.yml
+++ b/chart/templates/logstash_override.yml
@@ -52,7 +52,7 @@ data:
     {{- include "malcolm.ecstemplate" (dict "index_patterns" (printf "%s-*" .Values.siem_env.logstash_override.rollover_alias_suricata) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_suricata "ilm_policy" .Values.siem_env.logstash_override.ilm_policy "search_alias" .Values.siem_env.logstash_override.search_alias) | indent 4 }}
 
   malcolm_beats_template.json: |
-    {{- include "malcolm.beatstemplate" (dict "index_patterns" (printf "%s_*" .Values.siem_env.logstash_override.rollover_alias_beats) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_beats "ilm_policy" .Values.siem_env.logstash_override.ilm_beats_policy "default_pipeline" .Values.siem_env.logstash_override.default_beats_pipeline) | indent 4 }}
+    {{- include "malcolm.beatstemplate" (dict "index_patterns" (printf "%s-*" .Values.siem_env.logstash_override.rollover_alias_beats) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_beats "ilm_policy" .Values.siem_env.logstash_override.ilm_beats_policy "default_pipeline" .Values.siem_env.logstash_override.default_beats_pipeline) | indent 4 }}
 kind: ConfigMap
 metadata:
   name: malcolm-template-override

--- a/chart/templates/logstash_override.yml
+++ b/chart/templates/logstash_override.yml
@@ -52,7 +52,7 @@ data:
     {{- include "malcolm.ecstemplate" (dict "index_patterns" (printf "%s-*" .Values.siem_env.logstash_override.rollover_alias_suricata) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_suricata "ilm_policy" .Values.siem_env.logstash_override.ilm_policy "search_alias" .Values.siem_env.logstash_override.search_alias) | indent 4 }}
 
   malcolm_beats_template.json: |
-    {{- include "malcolm.beatstemplate" (dict "index_patterns" (printf "%s-*" .Values.siem_env.logstash_override.rollover_alias_beats) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_beats "ilm_policy" .Values.siem_env.logstash_override.ilm_beats_policy "default_pipeline" .Values.siem_env.logstash_override.default_beats_pipeline) | indent 4 }}
+    {{- include "malcolm.beatstemplate" (dict "index_patterns" (printf "%s_*" .Values.siem_env.logstash_override.rollover_alias_beats) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_beats "ilm_policy" .Values.siem_env.logstash_override.ilm_beats_policy "default_pipeline" .Values.siem_env.logstash_override.default_beats_pipeline) | indent 4 }}
 kind: ConfigMap
 metadata:
   name: malcolm-template-override

--- a/chart/templates/logstash_override.yml
+++ b/chart/templates/logstash_override.yml
@@ -52,7 +52,7 @@ data:
     {{- include "malcolm.ecstemplate" (dict "index_patterns" (printf "%s-*" .Values.siem_env.logstash_override.rollover_alias_suricata) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_suricata "ilm_policy" .Values.siem_env.logstash_override.ilm_policy "search_alias" .Values.siem_env.logstash_override.search_alias) | indent 4 }}
 
   malcolm_beats_template.json: |
-    {{- include "malcolm.beatstemplate" (dict "index_patterns" (printf "%s-*" .Values.siem_env.logstash_override.rollover_alias_beats) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_beats "ilm_policy" .Values.siem_env.logstash_override.ilm_beats_policy) | indent 4 }}
+    {{- include "malcolm.beatstemplate" (dict "index_patterns" (printf "%s-*" .Values.siem_env.logstash_override.rollover_alias_beats) "rollover_alias" .Values.siem_env.logstash_override.rollover_alias_beats "ilm_policy" .Values.siem_env.logstash_override.ilm_beats_policy "default_pipeline" .Values.siem_env.logstash_override.default_beats_pipeline) | indent 4 }}
 kind: ConfigMap
 metadata:
   name: malcolm-template-override

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -114,6 +114,8 @@ siem_env:
     # Must match the patterns located inside of logstash_override.yml
     rollover_alias_zeek: malcolm_network_zeek
     rollover_alias_suricata: malcolm_network_suricata
+    rollover_alias_beats: malcolm_beats
+    ilm_beats_policy: logs
     search_alias: malcolm_network
     other_search_alias: ""
   # Index pattern for network traffic logs written via Logstash (e.g., Zeek logs, Suricata alerts)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -115,6 +115,7 @@ siem_env:
     rollover_alias_zeek: malcolm_network_zeek
     rollover_alias_suricata: malcolm_network_suricata
     rollover_alias_beats: malcolm_beats
+    default_beats_pipeline: sensor-status
     ilm_beats_policy: logs
     search_alias: malcolm_network
     other_search_alias: ""


### PR DESCRIPTION
Adds a way to override the ILM policy for Malcolm beats in order to properly clean things up.