### PR TITLE
changes to allow OpenSearch local mode to work in v25.06.0

### DIFF
--- a/chart/templates/logstash_override.yml
+++ b/chart/templates/logstash_override.yml
@@ -7,7 +7,7 @@ data:
       if [event][kind] == "metric" {
         elasticsearch {
           id => "output_opensearch_malcolm_metrics"
-          hosts => "${OPENSEARCH_URL:http://opensearch:9200}"
+          hosts => "${OPENSEARCH_URL:https://opensearch:9200}"
           ssl_certificate_verification => "false"
           manage_template => false
           document_id => "%{+YYMMdd}-%{[event][hash]}"
@@ -18,7 +18,7 @@ data:
       } else if [event][provider] == "suricata" {
         elasticsearch {
           id => "output_opensearch_malcolm_suricata"
-          hosts => "${OPENSEARCH_URL:http://opensearch:9200}"
+          hosts => "${OPENSEARCH_URL:https://opensearch:9200}"
           ssl_certificate_verification => "false"
           manage_template => false
           document_id => "%{+YYMMdd}-%{[event][hash]}"
@@ -29,7 +29,7 @@ data:
       } else {
         elasticsearch {
           id => "output_opensearch_malcolm_zeek"
-          hosts => "${OPENSEARCH_URL:http://opensearch:9200}"
+          hosts => "${OPENSEARCH_URL:https://opensearch:9200}"
           ssl_certificate_verification => "false"
           manage_template => false
           document_id => "%{+YYMMdd}-%{[event][hash]}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -79,7 +79,7 @@ opensearch:
   enabled: true
   singleNode: true
   replicas: 3
-  url: http://opensearch:9200
+  url: https://opensearch:9200
   dashboards_url: http://dashboards:5601/dashboards
   development:
     java_memory: -Xmx10g -Xms10g -Xss256k
@@ -95,7 +95,7 @@ external_elasticsearch:
   es_port: 9200
   kibana_port: 5601
   username: "malcolm"
-  password: ""
+  password: "malcolm_password"
   # Secret must be in following format if using elastic_secret_name:
   # apiVersion: v1
   #  data:


### PR DESCRIPTION
Changes to allow OpenSearch local mode to work

* change http://opensearch:9200 to https://opensearch:9200, as OpenSearch MUST be SSL internally in order to use security plugin
* also, set default internal OpenSearch password in values.yaml for creating internal OpenSearch service account for other services to connect to

Tested with Vagrantfile deployment method.