### PR TITLE
Added nfs-subdir-external-provisioner README.md section

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ nfs-subdir-external-provisioner-7ff748465c-q5hbl   1/1     Running     0        
 test-pod                                           0/1     Completed   0          7m31s
 </pre>
 
-The PerstentVolumeClaim should make a new directory in the NFS export and the Pod is designed to exit after creating a "SUCCESS" file in that directory. The test-pod shows a status of "Completed" because the pod already started, created the file, and exited. Check the NFS directory to verify a new directory has been create and it contains a file named "SUCCESS".
+The PerstentVolumeClaim should make a new directory in the NFS export and the Pod is designed to exit after creating a "SUCCESS" file in that directory. The test-pod shows a status of "Completed" because the pod already started, created the file, and exited. Check the NFS directory to verify a new directory has been created and it contains a file named "SUCCESS".
 
 <pre>
 nfs-subdir-provisioner$ ls -al

--- a/README.md
+++ b/README.md
@@ -177,8 +177,10 @@ $ kubectl get sc -A
 ```
 
 returns:
-<pre>NAME                   PROVISIONER                                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
-     nfs-client             cluster.local/nfs-subdir-external-provisioner            Delete          Immediate                  true            16s</pre>
+<pre>
+        NAME                   PROVISIONER                                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+     nfs-client             cluster.local/nfs-subdir-external-provisioner         Delete          Immediate                  true            16s
+</pre>
 
 You will see a new nfs-subdir-external-provisioner pod is now running in the default namespace
 
@@ -187,10 +189,10 @@ $ kubectl get pods -A
 ```
 
 returns:
-><pre>
->     NAMESPACE       NAME                                               READY   STATUS              RESTARTS      AGE
->     default         nfs-subdir-external-provisioner-7ff748465c-ssf7s   1/1     Running             0             32s
-></pre>
+<pre>
+        NAMESPACE       NAME                                               READY   STATUS              RESTARTS      AGE
+        default         nfs-subdir-external-provisioner-7ff748465c-ssf7s   1/1     Running             0             32s
+</pre>
 
 ### Test the newly installed nfs-subdir-external-provisioner
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,26 @@ Check the chart/values.yaml file for all the features that can be enabled disabl
 2. `cd <project dir that contains chart foler>`
 3. `helm install malcolm chart/ -n malcolm`
 
+
+## Storage Provisioner Options
+
+Malcolm-Helm's chart/values.yaml file defaults to the Rancher [local-path provisioner](https://github.com/rancher/local-path-provisioner) which leverages a part of the Kubernetes node's storage. As stated above, any storage provider that supports ReadWriteMany may be employed. This section will review how to configure the [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) for Kubernetes clusters with an available NFS server. 
+
+### Configure NFS server
+
+The [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) relies on an external NFS server to provide for Kuberenetes Persistent Volumes. The first step is to install an NFS server where the Kuberentes cluster can access shared volumes. For Debian based systems (including Ubuntu) [this page](https://documentation.ubuntu.com/server/how-to/networking/install-nfs/index.html) details steps to install an NFS server with apt:
+```
+sudo apt install nfs-kernel-server
+sudo systemctl start nfs-kernel-server.service
+```
+
+With the NFS service installed and running, some directory must be exported for use by other systems. In this example we export a directory for the nfs-subdir-provisioner by first creating the folder structure on the local filesystem then adding the path to /etc/exports on the NFS server. To verify everything works properly we will start with fully-open permissions.
+
+```
+sudo mkdir -p /exports/malcolm/nfs-subdir-provisioner
+sudo chmod -R 777 /exports/malcolm/nfs-subdir-provisioner/
+```
+
 ## Upgrade procedures
 
 Upgrading Malcolm-Helm to a new version of Malcolm requires manually applying the changes between the current and desired versions. To find the current version of Malcolm used by Malcolm-Helm, check the `appVersion` in the `Malcolm-Helm/chart/Chart.yaml` file.

--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ $ kubectl get sc -A
 
 returns:
 <pre>
-        NAME                   PROVISIONER                                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
-     nfs-client             cluster.local/nfs-subdir-external-provisioner         Delete          Immediate                  true            16s
+NAME                   PROVISIONER                                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+nfs-client             cluster.local/nfs-subdir-external-provisioner   Delete          Immediate              true                   16s
 </pre>
 
 You will see a new nfs-subdir-external-provisioner pod is now running in the default namespace
@@ -190,8 +190,8 @@ $ kubectl get pods -A
 
 returns:
 <pre>
-        NAMESPACE       NAME                                               READY   STATUS              RESTARTS      AGE
-        default         nfs-subdir-external-provisioner-7ff748465c-ssf7s   1/1     Running             0             32s
+NAMESPACE       NAME                                               READY   STATUS              RESTARTS      AGE
+default         nfs-subdir-external-provisioner-7ff748465c-ssf7s   1/1     Running             0             32s
 </pre>
 
 ### Test the newly installed nfs-subdir-external-provisioner

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ $ kubectl get sc -A
 ```
 
 returns:
->    NAME                   PROVISIONER                                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
->    nfs-client             cluster.local/nfs-subdir-external-provisioner            Delete          Immediate                  true            16s
+<pre>NAME                   PROVISIONER                                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+     nfs-client             cluster.local/nfs-subdir-external-provisioner            Delete          Immediate                  true            16s</pre>
 
 You will see a new nfs-subdir-external-provisioner pod is now running in the default namespace
 
@@ -187,8 +187,10 @@ $ kubectl get pods -A
 ```
 
 returns:
-><pre>NAMESPACE       NAME                                               READY   STATUS              RESTARTS      AGE</pre>
-><pre>default         nfs-subdir-external-provisioner-7ff748465c-ssf7s   1/1     Running             0             32s</pre>
+><pre>
+>     NAMESPACE       NAME                                               READY   STATUS              RESTARTS      AGE
+>     default         nfs-subdir-external-provisioner-7ff748465c-ssf7s   1/1     Running             0             32s
+></pre>
 
 ### Test the newly installed nfs-subdir-external-provisioner
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Check the chart/values.yaml file for all the features that can be enabled disabl
 
 ## Storage Provisioner Options
 
-Malcolm-Helm's chart/values.yaml file defaults to the Rancher [local-path](https://github.com/rancher/local-path-provisioner) storage provisioner which allocates storage from the Kubernetes nodes. As stated above, any storage provider that supports ReadWriteMany may be employed for Malcolm-Helm. This section will review how to configure the [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) for enviroments with an NFS server available. 
+Malcolm-Helm's chart/values.yaml file defaults to the Rancher [local-path](https://github.com/rancher/local-path-provisioner) storage provisioner which allocates storage from the Kubernetes nodes. As stated above, any storage provider that supports the ReadWriteMany access mode may be employed for Malcolm-Helm. This section will review how to configure the [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) for enviroments with an NFS server available. 
 
 ### Configure an NFS server
 
@@ -114,7 +114,7 @@ sudo apt install nfs-kernel-server
 sudo systemctl start nfs-kernel-server.service
 ```
 
-With the NFS service installed and running, a directory must be exported for use by the Kubernetes provisioner. In this example we export a directory for the nfs-subdir-provisioner by first creating a folder structure on the local server filesystem then add that path to /etc/exports on the NFS server. To verify everything works properly we will start with fully-open directory permissions.
+With the NFS service installed and running, a directory must be exported for use by the Kubernetes provisioner. In this example we export a directory for the nfs-subdir-provisioner by first creating a folder structure on the server's local filesystem then add that path to /etc/exports on the NFS server. To verify everything works properly we will start with fully-open directory permissions.
 
 ```
 sudo mkdir -p /exports/malcolm/nfs-subdir-provisioner
@@ -160,7 +160,7 @@ sudo apt install nfs-common -y
 
 The [nfs-subdir-exeternal-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) can be installed via Helm, Kustomize, or manually via a set of YAML files. Since Malcolm-Helm is a Helm based project we will also install the provisioner [via Helm](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner?tab=readme-ov-file#with-helm).
 
-For these steps we will need the NFS server IP address or DNS name as well as the NFS exported path from above. In the following example the server's DNS name is "nfsserver.malcolm.local" and the exported path on that server is "/exports/malcolm/nfs-subdir-provisioner". Notice: the NFS export path is /exports but we can point the nfs-subdir-external-provisioner to a sub-directory within the exported path (/exports/malcolm/nfs-subdir-provisioner) to keep the automatically generated files contained to that directory. We start by adding the Helm repo then install the provisioner with the server name and export path as parameters.
+For these steps we will need the NFS server IP address or DNS name as well as the NFS exported path from above. In the following example the server's DNS name is "nfsserver.malcolm.local" and the exported path on that server is "/exports/malcolm/nfs-subdir-provisioner". Notice: the NFS server's export path is actually /exports but we can point the nfs-subdir-external-provisioner to a sub-directory within the exported path (/exports/malcolm/nfs-subdir-provisioner) to keep the automatically generated files contained to that directory. We start by adding the Helm repo then install the provisioner with the server name and exported path as parameters.
  
 ```
 $ helm repo add nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
@@ -276,7 +276,7 @@ nfs-subdir-external-provisioner-7ff748465c-q5hbl   1/1     Running     0        
 test-pod                                           0/1     Completed   0          7m31s
 </pre>
 
-The PerstentVolumeClaim should make a new directory in the NFS export and the Pod is designed to exit after creating a "SUCCESS" file in that directory so it shows a status of "Completed". Check the NFS directory to verify a new directory has been create with a file named "SUCCESS".
+The PerstentVolumeClaim should make a new directory in the NFS export and the Pod is designed to exit after creating a "SUCCESS" file in that directory so it shows a status of "Completed" above. Check the NFS directory to verify a new directory has been create and it contains a file named "SUCCESS".
 
 <pre>
 nfs-subdir-provisioner$ ls -al
@@ -288,7 +288,7 @@ drwxrwxrwx  2 root  root  21 Jan 15 09:58 default-test-claim-pvc-20de4d0b-3e1c-4
 
 The directory should contain one file which was created when the Pod started.
 <pre>
-nfs-subdir-provisioner$ ls default-test-claim-pvc-20de4d0b-3e1c-4e7b-83c9-d6915a483328/
+nfs-subdir-provisioner$ ls default-test-claim-pvc-20de4d0b-3e1c-4e7b-83c9-d6915a483328
 SUCCESS
 </pre>
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ nfs-subdir-external-provisioner-7ff748465c-q5hbl   1/1     Running     0        
 test-pod                                           0/1     Completed   0          7m31s
 </pre>
 
-The PerstentVolumeClaim should make a new directory in the NFS export and the Pod is designed to exit after creating a "SUCCESS" file in that directory so it shows a status of "Completed" above. Check the NFS directory to verify a new directory has been create and it contains a file named "SUCCESS".
+The PerstentVolumeClaim should make a new directory in the NFS export and the Pod is designed to exit after creating a "SUCCESS" file in that directory. The test-pod shows a status of "Completed" because the pod already started, created the file, and exited. Check the NFS directory to verify a new directory has been create and it contains a file named "SUCCESS".
 
 <pre>
 nfs-subdir-provisioner$ ls -al
@@ -374,7 +374,7 @@ storage:
 
 ```
 
-Now follow the [Installation procedures](https://github.com/idaholab/Malcolm-Helm#installation-procedures) section above to deploy the Malcolm-Helm chart into your cluser.
+Now follow the [Installation procedures](#installation-procedures) section above to deploy the Malcolm-Helm chart into your cluser.
 
 ```
 1. `cd <project dir that contains chart foler>`

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ spec:
     requests:
       storage: 1Mi
 ```
-Note the storageClassName is set to "nfs-client" which matches the output of the "kubectl get sc -A" command above.
+Note: the storageClassName is set to "nfs-client" which matches the output of the "kubectl get sc -A" command above.
 
  
 The other [test file](https://raw.githubusercontent.com/kubernetes-sigs/nfs-subdir-external-provisioner/master/deploy/test-pod.yaml) defines a pod to make use of the newly created PersistentVolumeClaim.
@@ -276,7 +276,7 @@ nfs-subdir-external-provisioner-7ff748465c-q5hbl   1/1     Running     0        
 test-pod                                           0/1     Completed   0          7m31s
 </pre>
 
-The PerstentVolumeClaim should make a new directory in the NFS export and the Pod is designed to exit after createing a "SUCCESS" file in that directory so it has a status of "Completed". Check the NFS directory to verify a new directory has been create with a file named "SUCCESS".
+The PerstentVolumeClaim should make a new directory in the NFS export and the Pod is designed to exit after creating a "SUCCESS" file in that directory so it shows a status of "Completed". Check the NFS directory to verify a new directory has been create with a file named "SUCCESS".
 
 <pre>
 nfs-subdir-provisioner$ ls -al
@@ -304,7 +304,7 @@ persistentvolumeclaim "test-claim" deleted
 pod "test-pod" deleted
 </pre>
 
-The NFS directory will be marked as "archived" and can be manually deleted.
+The NFS directory will be renamed as "archived-default-test-claim-pvc...." and can be manually deleted.
 
 ```
 rm -rf archived-default-test-claim-pvc-20de4d0b-3e1c-4e7b-83c9-d6915a483328/

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ sudo apt install nfs-common -y
 
 ### Install the nfs-subdir-external-provisioner
 
-The [nfs-subdir-exeternal-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) can be installed via Helm, Kustomize, or manually via a set of YAML files. Since Malcolm-Helm is a Helm based project we will also install the provisioner via [Helm](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner?tab=readme-ov-file#with-helm).
+The [nfs-subdir-exeternal-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) can be installed via Helm, Kustomize, or manually via a set of YAML files. Since Malcolm-Helm is a Helm based project we will also install the provisioner [via Helm](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner?tab=readme-ov-file#with-helm).
 
-For these steps we will need the NFS server IP address or DNS name as well as the exported path from above. In the following example the server's DNS name is "nfsserver.malcolm.local" and the exported path to on that server is "/exports/malcolm/nfs-subdir-provisioner". Notice: the NFS export path is /exports but we can point the nfs-subdir-external-provisioner to a sub-directory within the exported path (/exports/malcolm/nfs-subdir-provisioner) to keep the automatically generated files contained to that directory. We start by adding the Helm repo then install the provisioner with the server name and export path as parameters. The storageClass.onDelete=true setting tells the provisioner not to archive the Kubernetes Persistent Volume Claim when deleting.
+For these steps we will need the NFS server IP address or DNS name as well as the exported path from above. In the following example the server's DNS name is "nfsserver.malcolm.local" and the exported path on that server is "/exports/malcolm/nfs-subdir-provisioner". Notice: the NFS export path is /exports but we can point the nfs-subdir-external-provisioner to a sub-directory within the exported path (/exports/malcolm/nfs-subdir-provisioner) to keep the automatically generated files contained to that directory. We start by adding the Helm repo then install the provisioner with the server name and export path as parameters. The storageClass.onDelete=true setting tells the provisioner not to archive the Kubernetes Persistent Volume Claim when deleting.
  
 ```
 $ helm repo add nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
@@ -170,23 +170,25 @@ $ helm install nfs-subdir-external-provisioner nfs-subdir-external-provisioner/n
     --set storageClass.onDelete=true
 ```
 
-Check the Storage Clas was successfully deployed to your Kubernetes cluster with the "get sc" command
+Check the Storage Class was successfully deployed to your Kubernetes cluster with the "get sc" command
 
 ```
 $ kubectl get sc -A
 ```
+
 returns:
-> 		NAME                   PROVISIONER                                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
-> nfs-client             cluster.local/nfs-subdir-external-provisioner            Delete          Immediate                  true            16s
+>    NAME                   PROVISIONER                                     RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+>    nfs-client             cluster.local/nfs-subdir-external-provisioner            Delete          Immediate                  true            16s
 
 You will see a new nfs-subdir-external-provisioner pod is now running in the default namespace
 
 ```
 $ kubectl get pods -A
 ```
+
 returns:
-> NAMESPACE       NAME                                               READY   STATUS              RESTARTS      AGE
-> default         nfs-subdir-external-provisioner-7ff748465c-ssf7s   1/1     Running             0             32s
+><pre>NAMESPACE       NAME                                               READY   STATUS              RESTARTS      AGE</pre>
+><pre>default         nfs-subdir-external-provisioner-7ff748465c-ssf7s   1/1     Running             0             32s</pre>
 
 ### Test the newly installed nfs-subdir-external-provisioner
 


### PR DESCRIPTION
Created new README.md section describing how to configure Malcolm-Helm for NFS server based PersistentVolumeClaims with [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner).