### PR TITLE
VDP-1132: Fix PCAP file rotation time and pipeline verbosity

### DIFF
--- a/chart/templates/26-pcap-processor.yml
+++ b/chart/templates/26-pcap-processor.yml
@@ -11,7 +11,7 @@ data:
   PCAP_PIPELINE_IGNORE_PREEXISTING: "true"
   PCAP_PIPELINE_POLLING: "false"
   PCAP_PIPELINE_POLLING_ASSUME_CLOSED_SEC: "10"
-  PCAP_PIPELINE_VERBOSITY: "-vv"
+  PCAP_PIPELINE_VERBOSITY: "{{ .Values.pcap_capture_env.pcap_pipeline_verbosity }}"
   EXTRA_TAGS: "{{ .Values.upload_common_env.extra_tags }}"
   OPENSEARCH_URL: ""
   OPENSEARCH_PRIMARY: ""

--- a/chart/templates/malcolm_configmaps.yaml
+++ b/chart/templates/malcolm_configmaps.yaml
@@ -290,6 +290,7 @@ data:
   PCAP_IFACE_TWEAK: "{{ .Values.pcap_capture_env.pcap_iface_tweak }}"
   PCAP_ROTATE_MEGABYTES: "{{ .Values.pcap_capture_env.pcap_rotate_megabytes }}"
   PCAP_ROTATE_MINUTES: "{{ .Values.pcap_capture_env.pcap_rotate_minutes }}"
+  PCAP_ROTATE_SECONDS: "{{ mul .Values.pcap_capture_env.pcap_rotate_minutes 60 }}"
 kind: ConfigMap
 metadata:
   name: pcap-capture-env
@@ -385,6 +386,12 @@ data:
   YARA_MAX_REQUESTS: "{{ .yara_max_requests }}"
   EXTRACTED_FILE_MAX_BYTES: "{{ .extracted_file_max_bytes }}"
   EXTRACTED_FILE_MIN_BYTES: "{{ .extracted_file_min_bytes }}"
+  # Prune ./zeek-logs/extract_files/ when it exceeds this size...
+  EXTRACTED_FILE_PRUNE_THRESHOLD_MAX_SIZE: "{{ .extracted_file_prune_threshold_max_size }}"
+  # ... or when the *total* disk usage exceeds this percentage
+  EXTRACTED_FILE_PRUNE_THRESHOLD_TOTAL_DISK_USAGE_PERCENT: "{{ .extracted_file_prune_threshold_total_disk_usage_percent }}"
+  # Interval in seconds for checking whether to prune ./zeek-logs/extract_files/
+  EXTRACTED_FILE_PRUNE_INTERVAL_SECONDS: "{{ .extracted_file_prune_interval_seconds }}"
     {{- end }}
   {{- else }}
     {{- with .Values.zeek_env.development }}
@@ -392,13 +399,13 @@ data:
   CLAMD_MAX_REQUESTS: "{{ .clamd_max_requests }}"
   YARA_MAX_REQUESTS: "{{ .yara_max_requests }}"
   EXTRACTED_FILE_MAX_BYTES: "{{ .extracted_file_max_bytes }}"
+  EXTRACTED_FILE_MIN_BYTES: "{{ .extracted_file_min_bytes }}"
   # Prune ./zeek-logs/extract_files/ when it exceeds this size...
   EXTRACTED_FILE_PRUNE_THRESHOLD_MAX_SIZE: "{{ .extracted_file_prune_threshold_max_size }}"
   # ... or when the *total* disk usage exceeds this percentage
   EXTRACTED_FILE_PRUNE_THRESHOLD_TOTAL_DISK_USAGE_PERCENT: "{{ .extracted_file_prune_threshold_total_disk_usage_percent }}"
   # Interval in seconds for checking whether to prune ./zeek-logs/extract_files/
   EXTRACTED_FILE_PRUNE_INTERVAL_SECONDS: "{{ .extracted_file_prune_interval_seconds }}"
-  EXTRACTED_FILE_MIN_BYTES: "{{ .extracted_file_min_bytes }}"
     {{- end }}
   {{- end }}
   EXTRACTED_FILE_CAPA_VERBOSE: "false"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -546,7 +546,7 @@ pcap_capture_env:
   pcap_rotate_minutes: 10
   home_net: "192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
   pcap_iface_tweak: true
-
+  pcap_pipeline_verbosity: "-v"
 
 # Shared settings across all live capture type things (IE: Zeek live, Suricata live, and Pcap capture)
 live_capture:


### PR DESCRIPTION
- Fix the problem where the PCAP pipeline verbosity is at the DEBUG level and is not changeable. Add a new variable to set the pipeline verbosity and set the default level to INFO.
- Fix the problem where the PCAP rotation time in minutes is ignored. This change converts the incoming value in minutes to seconds and appropriately sets the required environment value for it to have an effect.