### PR TITLE
VDP-1569: Fix Arkime not running on uploaded PCAPs

### DIFF
--- a/chart/templates/07-arkime.yml
+++ b/chart/templates/07-arkime.yml
@@ -125,9 +125,8 @@ spec:
           secret:
             secretName: opensearch-curlrc
         - name: arkime-pcap-volume
-          hostPath:
-            path: "{{ .Values.arkime_live.pcap_hostpath }}"
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: pcap-claim
 {{- if and .Values.external_elasticsearch.enabled .Values.external_elasticsearch.elastic_cert_name }}
         - name: elastic-cert
           secret:


### PR DESCRIPTION
In January 2024, the arkime offline deployment was changed so the uploaded PCAPs were no longer mounted into the container. This PR reverts that change.

I have tested this code and verified that arkime is now being run against the uploaded PCAPs. Verification consisted of examining the Elasticsearch `arkime_sessionsv3*` index for the session data from the uploaded PCAP.


