### PR TITLE
VDP-1888: Fix Arkime unable to download PCAPs

### DIFF
--- a/chart/templates/network_policies.yml
+++ b/chart/templates/network_policies.yml
@@ -121,6 +121,29 @@ spec:
         {{- end }}
 
 ---
+{{- /*
+Allow the arkime-deployment pod access to download PCAPs from cluster nodes (VDP-1888).
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: arkime-pcap-download
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      name: arkime-deployment
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+      - ipBlock:
+          cidr: {{ .Values.cluster.node_cidr | quote }}
+      ports:
+      - protocol: TCP
+        port: 8005
+
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,10 @@ enable_network_policies: false
 # or `pipeline` to have Zeek and Suricata ingest PCAP data streamed from Arkime.
 capture_mode: live
 
+cluster:
+  # Set to a CIDR mask that covers all the cluster nodes.
+  node_cidr: "10.0.0.0/8"
+
 # Label used by the _helpers.tpl scaling function to count nodes.
 # The total number of nodes with this label determines the number of replicas.
 # WARNING: If no nodes have this label, logstash replicas will be set to 0.


### PR DESCRIPTION
Add a netpol so that the arkime-deployment pod can access the arkime viewer service running on the cluster nodes.