### PR TITLE
VDP-2160: Retain credentials across deployments

### DIFF
--- a/chart/templates/malcolm_secrets.yaml
+++ b/chart/templates/malcolm_secrets.yaml
@@ -1,8 +1,30 @@
+{{- $fileExtractServerKey := randAlphaNum 14 }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace "zeek-secret-env" }}
+{{- if $existing }}
+  {{- $fileExtractServerKey = index $existing.data "EXTRACTED_FILE_HTTP_SERVER_KEY" | b64dec -}}
+{{- end }}
+
 {{- $redisPassword := randAlphaNum 25 }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace "redis-env" }}
+{{- if $existing }}
+  {{- $redisPassword = index $existing.data "REDIS_PASSWORD" | b64dec -}}
+{{- end }}
+
 {{- $netboxSuperUserPassword := randAlphaNum 25 }}
 {{- $netboxSecretKey := randAlphaNum 50 }}
 {{- $netboxSuperAPIToken := randAlphaNum 32 }}
-{{- $fileExtractServerKey := randAlphaNum 14 }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace "netbox-secret-env" }}
+{{- if $existing }}
+  {{- $netboxSuperUserPassword = index $existing.data "SUPERUSER_PASSWORD" | b64dec -}}
+  {{- $netboxSecretKey = index $existing.data "SECRET_KEY" | b64dec -}}
+  {{- $netboxSuperAPIToken = index $existing.data "SUPERUSER_API_TOKEN" | b64dec -}}
+{{- end }}
+
+{{- $postgresPassword := .Values.postgres.password | default (randAlphaNum 32) }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace "postgres-env" }}
+{{- if $existing }}
+  {{- $postgresPassword = index $existing.data "POSTGRES_PASSWORD" | b64dec -}}
+{{- end }}
 
 {{- if not .Values.auth.existingSecret }}
 ---
@@ -48,6 +70,8 @@ stringData:
 kind: Secret
 metadata:
   name: redis-env
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 
 ---
@@ -58,41 +82,44 @@ stringData:
   PGPORT: "5432"
   POSTGRES_DB: "postgres"
   POSTGRES_USER: "postgres"
-  POSTGRES_PASSWORD: "{{ .Values.postgres.password }}"
+  POSTGRES_PASSWORD: {{ $postgresPassword | quote }}
   POSTGRES_NETBOX_DB: "{{ .Values.postgres.netbox_db_name }}"
   POSTGRES_NETBOX_USER: "netbox"
-  POSTGRES_NETBOX_PASSWORD: "{{ .Values.postgres.password }}"
+  POSTGRES_NETBOX_PASSWORD: {{ $postgresPassword | quote }}
   POSTGRES_KEYCLOAK_DB: "{{ .Values.postgres.keycloak_db_name }}"
   POSTGRES_KEYCLOAK_USER: "keycloak"
-  POSTGRES_KEYCLOAK_PASSWORD: "{{ .Values.postgres.password }}"
+  POSTGRES_KEYCLOAK_PASSWORD: {{ $postgresPassword | quote }}
   POSTGRES_DISABLED: "{{ not .Values.postgres.enabled }}"  
 kind: Secret
 metadata:
   name: postgres-env
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
-
 ---
 apiVersion: v1
-data:
-  DB_USER: {{ "netbox" | b64enc }}
+stringData:
+  DB_USER: "netbox"
   EMAIL_PASSWORD: ""
-  EMAIL_USERNAME: {{ "netbox" | b64enc }}
+  EMAIL_USERNAME: "netbox"
   NAPALM_PASSWORD: ""
   NAPALM_USERNAME: ""
-  REDIS_CACHE_PASSWORD: {{ $redisPassword | b64enc }}
-  REDIS_PASSWORD: {{ $redisPassword | b64enc }}
-  SECRET_KEY: {{ $netboxSecretKey | b64enc }}
-  SUPERUSER_API_TOKEN: {{ $netboxSuperAPIToken | b64enc }}
-  SUPERUSER_NAME: {{ "admin" | b64enc }}
-  SUPERUSER_PASSWORD: {{ $netboxSuperUserPassword | b64enc }}
+  REDIS_CACHE_PASSWORD: {{ $redisPassword }}
+  REDIS_PASSWORD: {{ $redisPassword }}
+  SECRET_KEY: {{ $netboxSecretKey }}
+  SUPERUSER_API_TOKEN: {{ $netboxSuperAPIToken }}
+  SUPERUSER_NAME: "admin"
+  SUPERUSER_PASSWORD: {{ $netboxSuperUserPassword }}
   {{- if eq .Values.netbox.mode "remote" }}
-  NETBOX_TOKEN: "{{ .Values.netbox.netbox_remote_token | b64enc }}"
+  NETBOX_TOKEN: "{{ .Values.netbox.netbox_remote_token }}"
   {{- else }}
   NETBOX_TOKEN: ""
   {{- end }}
 kind: Secret
 metadata:
   name: netbox-secret-env
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 
 ---
@@ -107,12 +134,14 @@ type: Opaque
 
 ---
 apiVersion: v1
-data:
-  EXTRACTED_FILE_HTTP_SERVER_KEY: {{ $fileExtractServerKey| b64enc }}
-  VTOT_API2_KEY: MA==
+stringData:
+  EXTRACTED_FILE_HTTP_SERVER_KEY: {{ $fileExtractServerKey }}
+  VTOT_API2_KEY: "0"
 kind: Secret
 metadata:
   name: zeek-secret-env
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 
 {{- if or (eq .Values.auth.mode "keycloak") (eq .Values.auth.mode "keycloak_remote") }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -300,7 +300,8 @@ postgres:
   host: postgres
 
   # Default PostgreSQL password
-  password: "ChangeMe"
+  # If not provided, a random password is assigned.
+  password: ""
 
   # Database names for applications
   netbox_db_name: "netbox"


### PR DESCRIPTION
- Update the chart so that removal does NOT remove the credentials generated during deployment. This permits the chart to be re-installed without generating new credentials.