### PR TITLE
allow specifying default opensearch share index replica count

### DIFF
--- a/chart/templates/malcolm_configmaps.yaml
+++ b/chart/templates/malcolm_configmaps.yaml
@@ -282,9 +282,11 @@ data:
   cluster.routing.allocation.node_initial_primaries_recoveries: "8"
 {{- if .Values.opensearch.singleNode }}
   discovery.type: single-node
+  OPENSEARCH_DEFAULT_REPLICA_COUNT: "0"
 {{- else }}
   cluster.initial_cluster_manager_nodes: {{ template "malcolm.managerNodes" . }}
   discovery.type: ""
+  OPENSEARCH_DEFAULT_REPLICA_COUNT: "{{ .Values.opensearch.defaultReplicaCount }}"
 {{- end }}
   cluster.name: opensearch-cluster
   network.host: 0.0.0.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -149,7 +149,12 @@ opensearch:
     java_memory: -Xmx32g -Xms32g -Xss256k
     cluster_max_shards_per_node: 2500
   singleNode: true
+  # When singleNode: false, number of OpenSearch pods/nodes in the StatefulSet.
+  # This is cluster size, not index shard replication.
   replicas: 3
+  # When singleNode: false, number of replica shards per primary shard for new/default indices.
+  # typically <= data nodes - 1, often 1 for multi-node.
+  defaultReplicaCount: 1
   # When running multiple OpenSearch instances ("singleNode: false" above)
   # Specify a manually created Kubernetes secret 
   # containing a ca.crt and ca.key


### PR DESCRIPTION
From values.yaml:

```
  # When singleNode: false, number of OpenSearch pods/nodes in the StatefulSet.
  # This is cluster size, not index shard replication.
  replicas: 3
  # When singleNode: false, number of replica shards per primary shard for new/default indices.
  # typically <= data nodes - 1, often 1 for multi-node.
  defaultReplicaCount: 1
```