### PR TITLE
bump version for v26.05.2

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 
 # This is the chart version. It should *almost* match appVersion, although "converted"
 # to semver (e.g., appVersion 25.09.0 -> version 25.9.0)
-version: 26.5.1
+version: 26.5.2
 
 # This is the version number of the application being deployed. The application
 # version tracks the Malcolm release number (https://github.com/idaholab/Malcolm/releases),
 # which follows calendar versioning (https://calver.org/), e.g., 25.09.0.
 # This variable is also used to determine the tag of the Malcolm container
 # images pulled (unless overridden in values.yaml).
-appVersion: "26.05.1"
+appVersion: "26.05.2"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 
 # This is the chart version. It should *almost* match appVersion, although "converted"
 # to semver (e.g., appVersion 25.09.0 -> version 25.9.0)
-version: 26.5.0
+version: 26.5.1
 
 # This is the version number of the application being deployed. The application
 # version tracks the Malcolm release number (https://github.com/idaholab/Malcolm/releases),
 # which follows calendar versioning (https://calver.org/), e.g., 25.09.0.
 # This variable is also used to determine the tag of the Malcolm container
 # images pulled (unless overridden in values.yaml).
-appVersion: "26.05.0"
+appVersion: "26.05.1"


### PR DESCRIPTION
No changes to the chart itself for this one, only bumping the version number for [v26.05.2](https://github.com/idaholab/Malcolm/releases/tag/v26.05.2).
