### PR TITLE
Leverage Kubernetes default storage class unless otherwise specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,17 +435,35 @@ rm -rf archived-default-test-claim-pvc-20de4d0b-3e1c-4e7b-83c9-d6915a483328/
 
 ### <a name="NFSMalcolmConfig"></a>Configure Malcolm-Helm to use the nfs-subdir-external-provisioner
 
-With the NFS server exports configured correctly and the Kubernetes nfs-subdir-external-provisioner able to access them for PersistentVolumeClaims, Malcolm-Helm is ready to be configured for deployment. As stated [above](#StorageProvisioner), the Malcolm-Helm [`values.yaml` file](https://github.com/idaholab/Malcolm-Helm/blob/main/chart/values.yaml) defaults to the Rancher [local-path](https://github.com/rancher/local-path-provisioner) storage provisioner. This is defined at the top of `values.yaml` by `storage_class_name`, which can be changed to `nfs-client` to leverage the `nfs-subpath-external-provisioner` and the NFS server exports:
+With the NFS server exports configured correctly and the Kubernetes nfs-subdir-external-provisioner able to access them for PersistentVolumeClaims, Malcolm-Helm is ready to be configured for deployment. As stated [above](#StorageProvisioner), the Malcolm-Helm [`values.yaml` file](https://github.com/idaholab/Malcolm-Helm/blob/main/chart/values.yaml) doesn't specify a storage storage class which is defined at the top of `values.yaml` as `storage_class_name:`. You can either set your cluster's default StorageClass object (see [above](#StorageProvisioner)) or change the `storage_class_name:` value to `nfs-client` which will explicitly leverage the `nfs-subpath-external-provisioner` and the NFS server exports:
 
 ```yaml
-# The StorageClass used for persistent volumes. Defaults to `local-path` (Local Path Provisioner).
-# If your cluster doesn't support this, set `storage_class_name` to another class that supports
-# ReadWriteMany. You can also override it at install time, e.g.:
-#    helm install --set "storage_class_name=nfs-client"
+# The StorageClass used for Malcolm persistent volumes. 
+# Defaults to "" which uses your cluser's default Kubernetes StorageClass.
+# (can be overridden on a per-component basis in the storage: section below) 
+#
+# Check your cluster's default StorageClass with: "kubectl get storageclass"
+# You should see a list of installed storage classes and, potentially, one marked "default"
+#
+#   $ kubectl get storageclass
+#   NAME                   PROVISIONER                                     
+#   local-path (default)   rancher.io/local-path                           
+#   nfs-client             cluster.local/nfs-subdir-external-provisioner   
+#
+# Change your default StorageClass with "kubectl patch storageclass"
+#
+#   $ kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+#   storageclass.storage.k8s.io/nfs-client patched
+# 
+# (Note: more than one StorageClass can be set to default. Patch with "is-default-class": "false" to disable unwated defaults.)
+# see: https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
+#
+# The selected StorageClass must support the ReadWriteMany access mode. You can also override it at install time, e.g.:
+#   helm install --set "storage_class_name=nfs-client"
 storage_class_name: nfs-client
 ```
 
-If further customization were needed -- for example, using different storage classes for different claims -- it could be accomplished by overriding the individual claims with `classNameOverride` in the `storage` section of `values.yaml`.
+If further customization were needed -- for example, using different storage classes for different claims -- it could be accomplished by overriding the individual claims with `classNameOverride` in the `storage:` section of `values.yaml`.
 
 Now, follow the [Installation procedures](#installation-procedures) section above to deploy the Malcolm-Helm chart into your cluser.
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,41 @@ Furthermore, the Kibana interface (specified via `dashboards_url`) is still expe
 
 ## <a name="StorageProvisioner"></a>Storage Provisioner Options
 
-Malcolm-Helm's `chart/values.yaml` file defaults to the Rancher [local-path](https://github.com/rancher/local-path-provisioner) storage provisioner which allocates storage from the Kubernetes nodes' local storage. As stated [above](#ProductionReqs), any storage provider that supports the `ReadWriteMany` access mode may be employed for Malcolm-Helm. This section provides an example of how to configure the [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) for enviroments with an NFS server available.
+Malcolm-Helm's `chart/values.yaml` file doesn't specify a storage class (storage_class_name: "") which allows Kubernetes to choose the cluster's default StorageClass object. You can detemine your cluster's default StorageClass with:
+
+```bash
+kubectl get storageclass
+```
+
+You should see a list of installed storage classes and, potentially, one or more marked "default"
+
+>$ kubectl get storageclass    
+>NAME                   PROVISIONER    
+>local-path (default)   rancher.io/local-path    
+>nfs-client             cluster.local/nfs-subdir-external-provisioner    
+
+Change your cluster's default StorageClass object by removing the "is-default-class" annotation from any existing defaults:
+
+```bash
+kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+```
+
+Then add that annotation for to the StoragClass you want as the new default:
+
+```bash
+kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+```
+
+Now your cluster should show the StorageClass with the newly added annonation as the default
+
+>$ kubectl get storageclass    
+>NAME                   PROVISIONER    
+>local-path             rancher.io/local-path    
+>nfs-client (default)   cluster.local/nfs-subdir-external-provisioner   
+
+Note: Multiple StorageClasses may be marked as default. Multiple defaults will cause a PersistentVolumeClaim to be created using the most recently created default StorageClass <sup>[1](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/)</sup>
+
+As stated [above](#ProductionReqs), any storage provider that supports the `ReadWriteMany` access mode may be employed for Malcolm-Helm. This section provides an example of how to configure the [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) for enviroments with an NFS server available.
 
 ### <a name="NFSServer"></a>Configure an NFS server
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Furthermore, the Kibana interface (specified via `dashboards_url`) is still expe
 
 ## <a name="StorageProvisioner"></a>Storage Provisioner Options
 
-Malcolm-Helm's `chart/values.yaml` file doesn't specify a storage class (storage_class_name: "") which allows Kubernetes to choose the cluster's default StorageClass object. You can detemine your cluster's default StorageClass with:
+Malcolm-Helm's `chart/values.yaml` file doesn't specify a storage class (storage_class_name: "") which allows Kubernetes to choose the cluster's default StorageClass object. You can determine your cluster's default StorageClass with:
 
 ```bash
 kubectl get storageclass
@@ -213,13 +213,13 @@ Change your cluster's default StorageClass object by removing the "is-default-cl
 kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 ```
 
-Then add that annotation for to the StoragClass you want as the new default:
+Then add that annotation to the StorageClass you want as the new default:
 
 ```bash
 kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ```
 
-Now your cluster should show the StorageClass with the newly added annonation as the default
+Now your cluster should show the StorageClass with the newly added annotation as the default
 
 >$ kubectl get storageclass    
 >NAME                   PROVISIONER    
@@ -435,7 +435,7 @@ rm -rf archived-default-test-claim-pvc-20de4d0b-3e1c-4e7b-83c9-d6915a483328/
 
 ### <a name="NFSMalcolmConfig"></a>Configure Malcolm-Helm to use the nfs-subdir-external-provisioner
 
-With the NFS server exports configured correctly and the Kubernetes nfs-subdir-external-provisioner able to access them for PersistentVolumeClaims, Malcolm-Helm is ready to be configured for deployment. As stated [above](#StorageProvisioner), the Malcolm-Helm [`values.yaml` file](https://github.com/idaholab/Malcolm-Helm/blob/main/chart/values.yaml) doesn't specify a storage storage class which is defined at the top of `values.yaml` as `storage_class_name:`. You can either set your cluster's default StorageClass object (see [above](#StorageProvisioner)) or change the `storage_class_name:` value to `nfs-client` which will explicitly leverage the `nfs-subpath-external-provisioner` and the NFS server exports:
+With the NFS server exports configured correctly and the Kubernetes nfs-subdir-external-provisioner able to access them for PersistentVolumeClaims, Malcolm-Helm is ready to be configured for deployment. As stated [above](#StorageProvisioner), the Malcolm-Helm [`values.yaml` file](https://github.com/idaholab/Malcolm-Helm/blob/main/chart/values.yaml) doesn't specify a storage class which is defined at the top of `values.yaml` as `storage_class_name:`. You can either set your cluster's default StorageClass object (see [above](#StorageProvisioner)) or change the `storage_class_name:` value to `nfs-client` which will explicitly leverage the `nfs-subpath-external-provisioner` and the NFS server exports:
 
 ```yaml
 # The StorageClass used for Malcolm persistent volumes. 

--- a/chart/templates/02-volumes.yml
+++ b/chart/templates/02-volumes.yml
@@ -8,7 +8,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: pcap-claim
 spec:
-  storageClassName: {{ default $global_storage_class_name .pcap_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .pcap_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
@@ -22,7 +24,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: zeek-claim
 spec:
-  storageClassName: {{ default $global_storage_class_name .zeek_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .zeek_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
@@ -36,7 +40,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: suricata-claim-offline
 spec:
-  storageClassName: {{ default $global_storage_class_name .suricata_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .suricata_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
@@ -50,7 +56,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: config-claim
 spec:
-  storageClassName: {{ default $global_storage_class_name .config_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .config_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
@@ -64,7 +72,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: runtime-logs-claim
 spec:
-  storageClassName: {{ default $global_storage_class_name .runtime_logs_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .runtime_logs_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
@@ -81,7 +91,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: pcap-claim
 spec:
-  storageClassName: {{ default $global_storage_class_name .pcap_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .pcap_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
@@ -95,7 +107,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: zeek-claim
 spec:
-  storageClassName: {{ default $global_storage_class_name .zeek_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .zeek_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
@@ -109,7 +123,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: suricata-claim-offline
 spec:
-  storageClassName: {{ default $global_storage_class_name .suricata_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .suricata_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
@@ -123,7 +139,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: config-claim
 spec:
-  storageClassName: {{ default $global_storage_class_name .config_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .config_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem
@@ -137,7 +155,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: runtime-logs-claim
 spec:
-  storageClassName: {{ default $global_storage_class_name .runtime_logs_claim.classNameOverride }}
+  {{- with (default $global_storage_class_name .runtime_logs_claim.classNameOverride) }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem

--- a/chart/templates/03-opensearch.yml
+++ b/chart/templates/03-opensearch.yml
@@ -61,7 +61,9 @@ spec:
     - metadata:
         name: opensearch-claim
       spec:
-        storageClassName: {{ default $global_storage_class_name .opensearch_claim.classNameOverride }}
+        {{- with (default $global_storage_class_name .opensearch_claim.classNameOverride) }}
+        storageClassName: {{ . }}
+        {{- end }}
         accessModes:
           - ReadWriteOnce
         volumeMode: Filesystem
@@ -71,7 +73,9 @@ spec:
     - metadata:
         name: opensearch-backup-claim
       spec:
-        storageClassName: {{ default $global_storage_class_name .opensearch_backup_claim.classNameOverride }}
+        {{- with (default $global_storage_class_name .opensearch_backup_claim.classNameOverride) }}
+        storageClassName: {{ . }}
+        {{- end }}
         accessModes:
           - ReadWriteOnce
         volumeMode: Filesystem
@@ -84,7 +88,9 @@ spec:
     - metadata:
         name: opensearch-claim
       spec:
-        storageClassName: {{ default $global_storage_class_name .opensearch_claim.classNameOverride }}
+        {{- with (default $global_storage_class_name .opensearch_claim.classNameOverride) }}
+        storageClassName: {{ . }}
+        {{- end }}
         accessModes:
           - ReadWriteOnce
         volumeMode: Filesystem
@@ -94,7 +100,9 @@ spec:
     - metadata:
         name: opensearch-backup-claim
       spec:
-        storageClassName: {{ default $global_storage_class_name .opensearch_backup_claim.classNameOverride }}
+        {{- with (default $global_storage_class_name .opensearch_backup_claim.classNameOverride) }}
+        storageClassName: {{ . }}
+        {{- end }}
         accessModes:
           - ReadWriteOnce
         volumeMode: Filesystem

--- a/chart/templates/17-postgres.yml
+++ b/chart/templates/17-postgres.yml
@@ -44,7 +44,9 @@ spec:
     - metadata:
         name: postgres-claim
       spec:
-        storageClassName: {{ default $global_storage_class_name .postgres_claim.classNameOverride }}
+        {{- with (default $global_storage_class_name .postgres_claim.classNameOverride) }}
+        storageClassName: {{ . }}
+        {{- end }}
         accessModes:
           - ReadWriteOnce
         volumeMode: Filesystem
@@ -57,7 +59,9 @@ spec:
     - metadata:
         name: postgres-claim
       spec:
-        storageClassName: {{ default $global_storage_class_name .postgres_claim.classNameOverride }}
+        {{- with (default $global_storage_class_name .postgres_claim.classNameOverride) }}
+        storageClassName: {{ . }}
+        {{- end }}
         accessModes:
           - ReadWriteOnce
         volumeMode: Filesystem

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -43,7 +43,7 @@ node_count_label:
 ca_trust_configmap_name: "var-local-catrust"
 
 # The StorageClass used for Malcolm persistent volumes. 
-# Defaults to "" which uses your cluser's default Kubernetes StorageClass.
+# Defaults to "" which uses your cluster's default Kubernetes StorageClass.
 # (can be overridden on a per-component basis in the storage: section below) 
 #
 # Check your cluster's default StorageClass with: "kubectl get storageclass"
@@ -59,7 +59,7 @@ ca_trust_configmap_name: "var-local-catrust"
 #   $ kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 #   storageclass.storage.k8s.io/nfs-client patched
 # 
-# (Note: more than one StorageClass can be set to default. Patch with "is-default-class": "false" to disable unwated defaults.)
+# (Note: more than one StorageClass can be set to default. Patch with "is-default-class": "false" to disable unwanted defaults.)
 # see: https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
 #
 # The selected StorageClass must support the ReadWriteMany access mode. You can also override it at install time, e.g.:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -42,11 +42,29 @@ node_count_label:
 #   of that name and import/mount them accordingly.
 ca_trust_configmap_name: "var-local-catrust"
 
-# The StorageClass used for persistent volumes. Defaults to `local-path` (Local Path Provisioner).
-# If your cluster doesn't support this, set `storage_class_name` to another class that supports
-# ReadWriteMany. You can also override it at install time, e.g.:
+# The StorageClass used for Malcolm persistent volumes. 
+# Defaults to "" which uses your cluser's default Kubernetes StorageClass.
+# (can be overridden on a per-component basis in the storage: section below) 
+#
+# Check your cluster's default StorageClass with: "kubectl get storageclass"
+# You should see a list of installed storage classes and, potentially, one marked "default"
+#
+#   $ kubectl get storageclass
+#   NAME                   PROVISIONER                                     
+#   local-path (default)   rancher.io/local-path                           
+#   nfs-client             cluster.local/nfs-subdir-external-provisioner   
+#
+# Change your default StorageClass with "kubectl patch storageclass"
+#
+#   $ kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+#   storageclass.storage.k8s.io/nfs-client patched
+# 
+# (Note: more than one StorageClass can be set to default. Patch with "is-default-class": "false" to disable unwated defaults.)
+# see: https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
+#
+# The selected StorageClass must support the ReadWriteMany access mode. You can also override it at install time, e.g.:
 #   helm install --set "storage_class_name=nfs-client"
-storage_class_name: local-path
+storage_class_name: ""
 
 image:
   repository: ghcr.io/idaholab/malcolm

--- a/vagrant_dependencies/sc.yaml
+++ b/vagrant_dependencies/sc.yaml
@@ -89,7 +89,7 @@ kind: StorageClass
 metadata:
   name: local-path
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete


### PR DESCRIPTION
This PR is in response to [Issue #14](https://github.com/idaholab/Malcolm-Helm/issues/14) "You should design it to use default sc by default."

Values.yaml "storage_class_name" now defaults to a blank string ("") which causes Kubernetes to utilize the Storage Class object marked "default".
Values.yaml comment section now explains how to check/set your default storage class.
Still allows for specifying a deployment wide storage_class_name in values.yaml.
Still supports the per-component storage class override in the "storage:" section.
Wrapped all Persistent Volume Claim spec sections in a {with} {end} to ensure the "storageClassName:" field is completely omitted in the Helm rendered output when no storage_class_name is specified.
Documentation pages updated to match the new behavior.
Update sc.yaml file so the local-path provisioner will be marked as default for Vagrant deployments.