### PR TITLE
changes for v26.06.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -360,8 +360,8 @@ EOF
       helm template malcolm /vagrant/chart -n #{malcolm_namespace} >/tmp/malcolm_rendered.yaml
       kubeconform -strict -ignore-missing-schemas /tmp/malcolm_rendered.yaml || echo "kubeconfirm failed!" >&2
       rm -f /tmp/malcolm_rendered.yaml
-      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --dry-run --set auth.existingSecret=malcolm-auth --set istio.enabled=true --set ingress.enabled=false --set pcap_capture_env.pcap_iface=#{vm_nic} >/dev/null || echo "Helm install --dry-run failed!" >&2
-      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --set auth.existingSecret=malcolm-auth --set istio.enabled=true --set ingress.enabled=false --set pcap_capture_env.pcap_iface=#{vm_nic}
+      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --dry-run --set auth.existingSecret=malcolm-auth --set istio.enabled=true --set ingress.enabled=false --set storage_class_name=local-path --set pcap_capture_env.pcap_iface=#{vm_nic} >/dev/null || echo "Helm install --dry-run failed!" >&2
+      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --set auth.existingSecret=malcolm-auth --set istio.enabled=true --set ingress.enabled=false --set storage_class_name=local-path --set pcap_capture_env.pcap_iface=#{vm_nic}
 
       grep -qxF '10.0.2.100 malcolm.vp.bigbang.dev malcolm.test.dev' /etc/hosts || echo '10.0.2.100 malcolm.vp.bigbang.dev malcolm.test.dev' >> /etc/hosts
       echo "You may now ssh to your kubernetes cluster using ssh -p 2222 vagrant@localhost" >&2
@@ -390,8 +390,8 @@ EOF
       helm template malcolm /vagrant/chart -n #{malcolm_namespace} >/tmp/malcolm_rendered.yaml
       kubeconform -strict -ignore-missing-schemas /tmp/malcolm_rendered.yaml || echo "kubeconfirm failed!" >&2
       rm -f /tmp/malcolm_rendered.yaml
-      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --dry-run --set auth.existingSecret=malcolm-auth --set istio.enabled=false --set ingress.enabled=true --set pcap_capture_env.pcap_iface=#{vm_nic} >/dev/null || echo "Helm install --dry-run failed!" >&2
-      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --set auth.existingSecret=malcolm-auth --set istio.enabled=false --set ingress.enabled=true --set pcap_capture_env.pcap_iface=#{vm_nic}
+      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --dry-run --set auth.existingSecret=malcolm-auth --set istio.enabled=false --set storage_class_name=local-path --set ingress.enabled=true --set pcap_capture_env.pcap_iface=#{vm_nic} >/dev/null || echo "Helm install --dry-run failed!" >&2
+      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --set auth.existingSecret=malcolm-auth --set istio.enabled=false --set storage_class_name=local-path --set ingress.enabled=true --set pcap_capture_env.pcap_iface=#{vm_nic}
 
       echo "You may now ssh to your kubernetes cluster using ssh -p 2222 vagrant@localhost" >&2
       hostname -I

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -360,8 +360,8 @@ EOF
       helm template malcolm /vagrant/chart -n #{malcolm_namespace} >/tmp/malcolm_rendered.yaml
       kubeconform -strict -ignore-missing-schemas /tmp/malcolm_rendered.yaml || echo "kubeconfirm failed!" >&2
       rm -f /tmp/malcolm_rendered.yaml
-      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --dry-run --set auth.existingSecret=malcolm-auth --set istio.enabled=true --set ingress.enabled=false --set storage_class_name=local-path --set pcap_capture_env.pcap_iface=#{vm_nic} >/dev/null || echo "Helm install --dry-run failed!" >&2
-      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --set auth.existingSecret=malcolm-auth --set istio.enabled=true --set ingress.enabled=false --set storage_class_name=local-path --set pcap_capture_env.pcap_iface=#{vm_nic}
+      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --dry-run --set auth.existingSecret=malcolm-auth --set istio.enabled=true --set ingress.enabled=false --set pcap_capture_env.pcap_iface=#{vm_nic} >/dev/null || echo "Helm install --dry-run failed!" >&2
+      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --set auth.existingSecret=malcolm-auth --set istio.enabled=true --set ingress.enabled=false --set pcap_capture_env.pcap_iface=#{vm_nic}
 
       grep -qxF '10.0.2.100 malcolm.vp.bigbang.dev malcolm.test.dev' /etc/hosts || echo '10.0.2.100 malcolm.vp.bigbang.dev malcolm.test.dev' >> /etc/hosts
       echo "You may now ssh to your kubernetes cluster using ssh -p 2222 vagrant@localhost" >&2
@@ -390,8 +390,8 @@ EOF
       helm template malcolm /vagrant/chart -n #{malcolm_namespace} >/tmp/malcolm_rendered.yaml
       kubeconform -strict -ignore-missing-schemas /tmp/malcolm_rendered.yaml || echo "kubeconfirm failed!" >&2
       rm -f /tmp/malcolm_rendered.yaml
-      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --dry-run --set auth.existingSecret=malcolm-auth --set istio.enabled=false --set storage_class_name=local-path --set ingress.enabled=true --set pcap_capture_env.pcap_iface=#{vm_nic} >/dev/null || echo "Helm install --dry-run failed!" >&2
-      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --set auth.existingSecret=malcolm-auth --set istio.enabled=false --set storage_class_name=local-path --set ingress.enabled=true --set pcap_capture_env.pcap_iface=#{vm_nic}
+      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --dry-run --set auth.existingSecret=malcolm-auth --set istio.enabled=false --set ingress.enabled=true --set pcap_capture_env.pcap_iface=#{vm_nic} >/dev/null || echo "Helm install --dry-run failed!" >&2
+      helm install malcolm /vagrant/chart -n #{malcolm_namespace} --set auth.existingSecret=malcolm-auth --set istio.enabled=false --set ingress.enabled=true --set pcap_capture_env.pcap_iface=#{vm_nic}
 
       echo "You may now ssh to your kubernetes cluster using ssh -p 2222 vagrant@localhost" >&2
       hostname -I

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 
 # This is the chart version. It should *almost* match appVersion, although "converted"
 # to semver (e.g., appVersion 25.09.0 -> version 25.9.0)
-version: 26.5.2
+version: 26.6.0
 
 # This is the version number of the application being deployed. The application
 # version tracks the Malcolm release number (https://github.com/idaholab/Malcolm/releases),
 # which follows calendar versioning (https://calver.org/), e.g., 25.09.0.
 # This variable is also used to determine the tag of the Malcolm container
 # images pulled (unless overridden in values.yaml).
-appVersion: "26.05.2"
+appVersion: "26.06.0"

--- a/chart/templates/arkime_configmaps.yml
+++ b/chart/templates/arkime_configmaps.yml
@@ -93,6 +93,15 @@ metadata:
   name: arkime-env
 
 ---
+{{- $arkime_secret_existing := (lookup "v1" "Secret" .Release.Namespace "arkime-secret-env") -}}
+{{- $arkime_hash_password := "" -}}
+{{- if .Values.auth.arkime_password -}}
+  {{- $arkime_hash_password = .Values.auth.arkime_password -}}
+{{- else if $arkime_secret_existing -}}
+  {{- $arkime_hash_password = index $arkime_secret_existing.data "ARKIME_PASSWORD_SECRET" | b64dec -}}
+{{- else -}}
+  {{- $arkime_hash_password = randAlphaNum 32 -}}
+{{- end -}}
 apiVersion: v1
 stringData:
   # MaxMind GeoIP database update API key
@@ -100,7 +109,7 @@ stringData:
   # Alternate download URL for MaxMind MMDB tarballs
   MAXMIND_GEOIP_DB_ALTERNATE_DOWNLOAD_URL: "{{ .Values.maxmind.alternate_url }}"
   # Internal password hash secret for Arkime viewer cluster (see https://arkime.com/settings#passwordSecret)
-  ARKIME_PASSWORD_SECRET: "{{ .Values.auth.arkime_password }}"
+  ARKIME_PASSWORD_SECRET: "{{ $arkime_hash_password }}"
   # If the Arkime WISE plugin is in use, this sets the configuration PIN for the WISE GUI
   ARKIME_WISE_CONFIG_PIN_CODE: "{{ .Values.auth.arkime_wise_pin }}"
 

--- a/chart/templates/malcolm_secrets.yaml
+++ b/chart/templates/malcolm_secrets.yaml
@@ -148,6 +148,7 @@ stringData:
   KEYCLOAK_AUTH_URL: "{{ .Values.keycloak.keycloak_auth_url }}"
   KEYCLOAK_CLIENT_ID: "{{ .Values.keycloak.keycloak_client_id }}"
   KEYCLOAK_CLIENT_SECRET: "{{ .Values.keycloak.keycloak_client_secret }}"
+  KEYCLOAK_SSL_VERIFY: "{{ .Values.keycloak.keycloak_ssl_verify }}"
   KC_CACHE: "{{ .Values.keycloak.kc_cache }}"
   KC_HEALTH_ENABLED: "{{ .Values.keycloak.kc_health_enabled }}"
   KC_HOSTNAME: "{{ .Values.keycloak.kc_hostname }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -120,7 +120,7 @@ auth:
   htpassCredKey: "htpass_cred"
 
   # Internal password hash secret for Arkime viewer cluster (see https://arkime.com/settings#passwordSecret)
-  arkime_password: malcolm
+  arkime_password: ""
 
   # If the Arkime WISE plugin is in use, this sets the configuration PIN for the WISE GUI
   # Users should change this value if using the WISE plugin GUI
@@ -976,6 +976,7 @@ keycloak:
   keycloak_auth_url: ""
   keycloak_client_id: ""
   keycloak_client_secret: ""
+  keycloak_ssl_verify: "false"
   kc_cache: "local"
   kc_health_enabled: "true"
   kc_hostname: ""


### PR DESCRIPTION
Minor changes for [Malcolm v26.06.0](https://github.com/idaholab/Malcolm/releases/tag/v26.06.0):

* bump chart and application version
* explicitly set `storage_class_name=local-path` in `helm install` commands
* added `KEYCLOAK_SSL_VERIFY` environment variable (default `false`)
* remove hard-coded `arkime_password` variable for the [arkime password hash secret](https://arkime.com/settings#passwordSecret); now defaults to a random string if unset at the values level

Tested on a k3s cluster as well as on the vagrant setup with and without istio