### PR TITLE
Malcolm v26.06.1 updates

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 
 # This is the chart version. It should *almost* match appVersion, although "converted"
 # to semver (e.g., appVersion 25.09.0 -> version 25.9.0)
-version: 26.6.0
+version: 26.6.1
 
 # This is the version number of the application being deployed. The application
 # version tracks the Malcolm release number (https://github.com/idaholab/Malcolm/releases),
 # which follows calendar versioning (https://calver.org/), e.g., 25.09.0.
 # This variable is also used to determine the tag of the Malcolm container
 # images pulled (unless overridden in values.yaml).
-appVersion: "26.06.0"
+appVersion: "26.06.1"

--- a/chart/templates/19-htadmin.yml
+++ b/chart/templates/19-htadmin.yml
@@ -64,9 +64,10 @@ spec:
             name: htadmin-config-volume
             subPath: "htadmin"
         livenessProbe:
-          exec:
-            command:
-            - /usr/local/bin/container_health.sh
+          # todo: restore container health check script once v26.07.0 is out and restores curl
+          httpGet:
+            path: /
+            port: 80
           initialDelaySeconds: 60
           periodSeconds: 60
           timeoutSeconds: 15

--- a/chart/templates/arkime_configmaps.yml
+++ b/chart/templates/arkime_configmaps.yml
@@ -104,7 +104,8 @@ metadata:
 {{- end -}}
 apiVersion: v1
 stringData:
-  # MaxMind GeoIP database update API key
+  # MaxMind GeoIP database update account ID and API key
+  MAXMIND_GEOIP_DB_ACCOUNT_ID: "{{ .Values.maxmind.account_id }}"
   MAXMIND_GEOIP_DB_LICENSE_KEY: "{{ .Values.maxmind.license_key }}"
   # Alternate download URL for MaxMind MMDB tarballs
   MAXMIND_GEOIP_DB_ALTERNATE_DOWNLOAD_URL: "{{ .Values.maxmind.alternate_url }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -775,6 +775,7 @@ zeek_env:
 
 
 maxmind:
+  account_id: ""
   license_key: ""
   alternate_url: ""
 


### PR DESCRIPTION
Updates for Malcolm v26.06.1. Pretty minor:

* change chart and application version
* temporarily add new liveness probe check for `htadmin` as workaround for https://github.com/cisagov/Malcolm/issues/1029 until the next release
* added `.Values.maxmind.account_id` to `values.yaml` to populate new `MAXMIND_GEOIP_DB_ACCOUNT_ID` variable in `chart/templates/arkime_configmaps.yml`

tested locally with Vagrantfile deployment and on local k3s cluster.